### PR TITLE
Uses new HAL method names

### DIFF
--- a/commandbased/commandbasedrobot.py
+++ b/commandbased/commandbasedrobot.py
@@ -19,28 +19,28 @@ class CommandBasedRobot(IterativeRobot):
         from IterativeRobot for readability and to initialize scheduler.
         """
 
-        hal.HALReport(hal.HALUsageReporting.kResourceType_Framework,
-                      hal.HALUsageReporting.kFramework_Iterative)
+        hal.report(hal.HALUsageReporting.kResourceType_Framework,
+                   hal.HALUsageReporting.kFramework_Iterative)
 
         self.scheduler = Scheduler.getInstance()
         self.robotInit()
 
         # Tell the DS that the robot is ready to be enabled
-        hal.HALNetworkCommunicationObserveUserProgramStarting()
+        hal.observeUserProgramStarting()
 
         # loop forever, calling the appropriate mode-dependent function
         while True:
             if self.ds.isDisabled():
                 self.disabledInit()
                 while self.ds.isDisabled():
-                    hal.HALNetworkCommunicationObserveUserProgramDisabled()
+                    hal.observeUserProgramDisabled()
                     self.disabledPeriodic()
                     self.ds.waitForData()
 
             elif self.ds.isAutonomous():
                 self.autonomousInit()
                 while self.ds.isAutonomous():
-                    hal.HALNetworkCommunicationObserveUserProgramAutonomous()
+                    hal.observeUserProgramAutonomous()
                     self.autonomousPeriodic()
                     self.ds.waitForData()
 
@@ -49,7 +49,7 @@ class CommandBasedRobot(IterativeRobot):
 
                 self.testInit()
                 while self.ds.isTest():
-                    hal.HALNetworkCommunicationObserveUserProgramTest()
+                    hal.observeUserProgramTest()
                     self.testPeriodic()
                     self.ds.waitForData()
 
@@ -61,7 +61,7 @@ class CommandBasedRobot(IterativeRobot):
                 # to check isEnabled as well, since otherwise it will continue
                 # looping while disabled.
                 while self.ds.isEnabled() and self.ds.isOperatorControl():
-                    hal.HALNetworkCommunicationObserveUserProgramTeleop()
+                    hal.observeUserProgramTeleop()
                     self.teleopPeriodic()
                     self.ds.waitForData()
 


### PR DESCRIPTION
This change just copies the [method name changes](https://github.com/robotpy/robotpy-wpilib/commit/480c0daabc1e57c536d085650d7b2f8d1fd1c618) made to the `IterativeRobot` class. We have no way to test this, but if `IterativeRobot` is correct than this should be correct as well.

It's worth noting that this class's `startCompetition` method should be functionally equivalent to the one in `IterativeRobot`, except for the [scheduler line](https://github.com/FRC2539/robotpy-wpilib-utilities/blob/halchanges/commandbased/commandbasedrobot.py#L25). We tried to simplify the `while True:` loop and were able to remove 20 lines of code from it (27 vs 47) and all of the state tracking variables that exist in the class only for this loop, without losing any functionality.

We humbly suggest replacing the `startCompetition` method in `IterativeRobot` with this version (minus the Scheduler line), and then we could simplify this class even further. 