### PR TITLE
onException should have a context manager wrapper version

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -1,4 +1,5 @@
 
+import contextlib
 import inspect
 import logging
 
@@ -196,6 +197,35 @@ class MagicRobot(wpilib.SampleRobot,
             pass    # ok, can't do anything here
 
         self.__last_error_report = now
+
+    @contextlib.contextmanager
+    def consumeExceptions(self, forceReport=False):
+        """
+            This returns a context manager which will consume any uncaught
+            exceptions that might otherwise crash the robot.
+
+            Example usage::
+
+                def teleopPeriodic(self):
+                    with self.consumeExceptions():
+                        if self.joystick.getTrigger():
+                            self.shooter.shoot()
+
+                    with self.consumeExceptions():
+                        if self.joystick.getRawButton(2):
+                            self.ball_intake.run()
+
+                    # and so on...
+
+            :param forceReport: Always report the exception to the DS. Don't
+                                set this to True
+
+            .. seealso:: :meth:`onException` for more details
+        """
+        try:
+            yield
+        except:
+            self.onException(forceReport=forceReport)
 
     #
     # Internal API


### PR DESCRIPTION
This is a call for feedback on an idea I've been pondering for a while.

Currently, the recommended thing to do to handle uncaught exceptions is to wrap blocks of code in a try-except:
```python
def teleopPeriodic(self):  # or whatever method
    try:
        doSomething()
    except:
        self.onException()
```

I feel this is two lines too much boilerplate. Hence, I propose the addition of a context generator, which will consume any exceptions raised, as a new way of handling uncaught exceptions.

However, I'm slightly stuck on what this should look like. There are two alternatives I've been thinking about:

```python
# The MagicBot class is the context manager.
def teleopPeriodic(self):
    with self:
        doSomething()
```

```python
# The MagicBot class has a consumeExceptions() method which returns a context manager.
def teleopPeriodic(self):
    with self.consumeExceptions():
        doSomething()
```

I'm slightly leaning towards the second option because it's clearer. What does everyone think?