### PR TITLE
Prevent errors when using properties

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -435,7 +435,7 @@ class MagicRobot(wpilib.SampleRobot,
         self.logger.debug("Injecting magic variables into %s", cname)
         
         for n in dir(component):
-            if n.startswith('_'):
+            if n.startswith('_') or isinstance(getattr(type(component), n, True), property):
                 continue
             
             inject_type = getattr(component, n)


### PR DESCRIPTION
Previously, if you tried to create a property, errors would occur when magicbot was doing its injection sequence. To prevent this, _setup_vars now filters out properties in addition to private methods