### PR TITLE
tunable: Allow setting docstring

### DIFF
--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -8,7 +8,7 @@ class _TunableProperty(property):
 class _AutosendProperty(_TunableProperty):
     pass
 
-def tunable(default, *, writeDefault=True, subtable=None):
+def tunable(default, *, writeDefault=True, subtable=None, doc=None):
     '''
         This allows you to define simple properties that allow you to easily
         communicate with other programs via NetworkTables.
@@ -69,7 +69,7 @@ def tunable(default, *, writeDefault=True, subtable=None):
         v = getattr(self, prop._ntattr)
         nt._api.setEntryValue(v.key, v._valuefn(value))
         
-    prop = _TunableProperty(fget=_get, fset=_set)
+    prop = _TunableProperty(fget=_get, fset=_set, doc=doc)
     prop._ntdefault = default
     prop._ntsubtable = subtable
     prop._ntwritedefault = writeDefault


### PR DESCRIPTION
In a similar fashion to robotpy/pynetworktables#44, this adds a `doc` keyword-only argument to `tunable`, allowing the user to specify a docstring for a `tunable`.