### PR TITLE
Clean up networktables for stateful autonomous

### DIFF
--- a/robotpy_ext/autonomous/stateful_autonomous.py
+++ b/robotpy_ext/autonomous/stateful_autonomous.py
@@ -218,7 +218,8 @@ class StatefulAutonomous:
             for k,v in components.items():
                 setattr(self, k, v)
         
-        self.__table = networktables.NetworkTable.getTable('SmartDashboard')
+        self.__table = networktables.NetworkTable.getTable('autonomous/%s/stateful' % getattr(self, 'MODE_NAME'  ))
+        
         self.__sd_args = []
 
         self.__build_states()
@@ -270,7 +271,7 @@ class StatefulAutonomous:
         sd_name = name
         
         if add_prefix:
-            sd_name = '%s\\%s' % (self.MODE_NAME, name) 
+            sd_name = name
         
         if isinstance(default, bool):
             self.__table.putBoolean(sd_name, default)
@@ -334,10 +335,10 @@ class StatefulAutonomous:
         
         sorted_states = sorted(states.items())
         
-        self.__table.putStringArray(self.MODE_NAME + '_durations',
+        self.__table.putStringArray('durations',
                                     (name for _, (name, desc) in sorted_states))
         
-        self.__table.putStringArray(self.MODE_NAME + '_descriptions',
+        self.__table.putStringArray('descriptions',
                                     (desc for _, (name, desc) in sorted_states))
         
         if not has_first:


### PR DESCRIPTION
Right now the organization of autonomous networktables values puts them directly in smart dashboard, causing lots of clutter, and it's very hard to navigate. 

<img width="852" alt="image" src="https://cloud.githubusercontent.com/assets/6132901/23478012/e56e89a8-fe8d-11e6-851d-1f5cc82821d3.png">

I suggest moving everything to an `autonomous` subtable, and then putting stateful autonomous metadata in its own folder
<img width="909" alt="image" src="https://cloud.githubusercontent.com/assets/6132901/23477965/b009cc78-fe8d-11e6-91ad-b4aa0d20b640.png">


Since this is breaking, leave until 2018.0.0