### PR TITLE
NavX: Fix getRate() returning 360°/s when stationary

### DIFF
--- a/robotpy_ext/common_drivers/navx/continuousangletracker.py
+++ b/robotpy_ext/common_drivers/navx/continuousangletracker.py
@@ -101,7 +101,7 @@ class ContinuousAngleTracker:
         if difference > 180.0:
             # Clockwise past +180 degrees
             difference = 360.0 - difference
-        else:
+        elif difference < -180.0:
             # Counter-clockwise past -180 degrees
             difference = 360.0 + difference
         


### PR DESCRIPTION
Somehow, someone neglected to add in a condition, breaking ContinuousAngleTracker.getRate() in the process.

Fixes: #50