### PR TITLE
Only look for types in annotation

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -438,7 +438,7 @@ class MagicRobot(wpilib.SampleRobot,
 
 
             # If the variable is private ignore it
-            if n.startswith('_'):
+            if n.startswith('_') or not isinstance(inject_type, type):
                 continue
 
             if hasattr(component_type, n):


### PR DESCRIPTION
`test: True` no longer breaks