### PR TITLE
Renamed StopCommand to CancelCommand

### DIFF
--- a/commandbased/__init__.py
+++ b/commandbased/__init__.py
@@ -1,3 +1,3 @@
 from .commandbasedrobot import CommandBasedRobot
 
-from .stopcommand import StopCommand
+from .cancelcommand import CancelCommand

--- a/commandbased/cancelcommand.py
+++ b/commandbased/cancelcommand.py
@@ -1,6 +1,6 @@
 from wpilib.command import InstantCommand
 
-class StopCommand(InstantCommand):
+class CancelCommand(InstantCommand):
     '''
     When this command is run, it cancels the command it was passed, even if that
     command is part of a :class:`wpilib.CommandGroup`.
@@ -9,9 +9,9 @@ class StopCommand(InstantCommand):
 
     def __init__(self, command):
         '''
-            :param command: The :class:`wpilib.Command` to stop.
+            :param command: The :class:`wpilib.Command` to cancel.
         '''
-        super().__init__('Stop %s' % command)
+        super().__init__('Cancel %s' % command)
 
         self.command = command
 


### PR DESCRIPTION
It became obvious almost as soon as the season started that we had misnamed this command.