### PR TITLE
Fix DeprecationWarnings

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -117,7 +117,7 @@ class MagicRobot(wpilib.SampleRobot,
         """
         func = self.teleopPeriodic.__func__
         if not hasattr(func, "firstRun"):
-            self.logger.warn("Default MagicRobot.teleopPeriodic() method... Overload me!")
+            self.logger.warning("Default MagicRobot.teleopPeriodic() method... Overload me!")
             func.firstRun = False
 
     def disabledInit(self):
@@ -144,7 +144,7 @@ class MagicRobot(wpilib.SampleRobot,
         """
         func = self.disabledPeriodic.__func__
         if not hasattr(func, "firstRun"):
-            self.logger.warn("Default MagicRobot.disabledPeriodic() method... Overload me!")
+            self.logger.warning("Default MagicRobot.disabledPeriodic() method... Overload me!")
             func.firstRun = False
 
     def onException(self, forceReport=False):

--- a/robotpy_ext/autonomous/selector.py
+++ b/robotpy_ext/autonomous/selector.py
@@ -90,7 +90,7 @@ class AutonomousModeSelector:
                 raise
             
             # Don't kill the robot because they didn't create an autonomous package
-            logger.warn("Cannot load the '%s' package", autonomous_pkgname)
+            logger.warning("Cannot load the '%s' package", autonomous_pkgname)
         else:
             if hasattr(autonomous_pkg, '__file__'):
                 modules_path = os.path.dirname(os.path.abspath(autonomous_pkg.__file__))
@@ -123,7 +123,7 @@ class AutonomousModeSelector:
                     
                     # don't allow the driver to select this mode 
                     if hasattr(obj, 'DISABLED') and obj.DISABLED:
-                        logger.warn("autonomous mode %s is marked as disabled", obj.MODE_NAME)
+                        logger.warning("autonomous mode %s is marked as disabled", obj.MODE_NAME)
                         continue
                     
                     try:
@@ -167,7 +167,7 @@ class AutonomousModeSelector:
             mode_names.append(k)
         
         if len(self.modes) == 0:
-            logger.warn("-- no autonomous modes were loaded!")
+            logger.warning("-- no autonomous modes were loaded!")
                 
         self.chooser.addObject('None', None)
         
@@ -274,7 +274,7 @@ class AutonomousModeSelector:
             logger.info("Enabling '%s'" % self.active_mode.MODE_NAME)
             self.active_mode.on_enable()
         else:
-            logger.warn("No autonomous modes were selected, not enabling autonomous mode")
+            logger.warning("No autonomous modes were selected, not enabling autonomous mode")
  
     def _on_autonomous_disable(self):
         '''Disable the active autonomous mode'''

--- a/robotpy_ext/autonomous/stateful_autonomous.py
+++ b/robotpy_ext/autonomous/stateful_autonomous.py
@@ -20,52 +20,47 @@ def __get_state_serial():
     return __global_cnt_serial[0]
 
 def _create_wrapper(f, first):
-    
+    # inspect the args, provide a correct call implementation
+    allowed_args = 'self', 'tm', 'state_tm', 'initial_call'
+    sig = inspect.signature(f)
+    name = f.__name__
+
+    args = []
+    invalid_args = []
+    for i, arg in enumerate(sig.parameters.values()):
+        if i == 0 and arg.name != 'self':
+            raise ValueError("First argument to %s must be 'self'" % name)
+        if arg.kind is arg.VAR_POSITIONAL:
+            raise ValueError("Cannot use *args in signature for function %s" % name)
+        if arg.kind is arg.VAR_KEYWORD:
+            raise ValueError("Cannot use **kwargs in signature for function %s" % name)
+        if arg.kind is arg.KEYWORD_ONLY:
+            raise ValueError("Currently cannot use keyword-only parameters for function %s" % name)
+        if arg.name in allowed_args:
+            args.append(arg.name)
+        else:
+            invalid_args.append(arg.name)
+
+    if invalid_args:
+        raise ValueError("Invalid parameter names in %s: %s" % (name, ','.join(invalid_args)))
+
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         return f(*args, **kwargs)
-    
+
     # store state variables here
     wrapper.origin = __name__
-    wrapper.name = f.__name__
+    wrapper.name = name
     wrapper.description = f.__doc__
     wrapper.ran = False
     wrapper.first = first
     wrapper.expires = 0xffffffff
     wrapper.serial = __get_state_serial()
-    
-    # inspect the args, provide a correct call implementation
-    args, varargs, keywords, _ = inspect.getargspec(f)
-    
-    if keywords is not None:
-        raise ValueError("Cannot use keyword arguments for function %s" % wrapper.name)
-    
-    if varargs is not None:
-        raise ValueError("Cannot use *args arguments for function %s" % wrapper.name)
-    
-    if args[0] != 'self':
-        raise ValueError("First argument must be 'self'")
-    
-    # TODO: there has to be a better way to do this. oh well. it only runs once.
-    
-    if len(args) > 4:
-        raise ValueError("Too many parameters for %s" % wrapper.name)
-    
-    wrapper_creator = 'w = lambda self, tm, state_tm, initial_call: f(%s)' % ','.join(args)
-    
-    for arg in ['self', 'tm', 'state_tm', 'initial_call']:
-        try:
-            args.remove(arg)
-        except ValueError:
-            pass
-    
-    if len(args) != 0:
-        raise ValueError("Invalid parameter names in %s: %s" % (wrapper.name, ','.join(args)))
-    
+
     varlist = {'f': f}
-    exec(wrapper_creator, varlist, varlist)
-    
-    wrapper.run = varlist['w']    
+    wrapper_creator = 'lambda self, tm, state_tm, initial_call: f(%s)' % ','.join(args)
+    wrapper.run = eval(wrapper_creator, varlist, varlist)
+
     return wrapper
 
 
@@ -458,5 +453,3 @@ class StatefulAutonomous:
         
         # execute the state function, passing it the arguments
         state.run(self, tm, tm - state.start_time, initial_call)
-
-    

--- a/robotpy_ext/common_drivers/navx/registerio.py
+++ b/robotpy_ext/common_drivers/navx/registerio.py
@@ -84,7 +84,7 @@ class RegisterIO:
             # initial device configuration
             self.setUpdateRateHz(self.update_rate_hz)
             if not self.getConfiguration():
-                logger.warn("-- Did not get configuration data")
+                logger.warning("-- Did not get configuration data")
             else:
                 logger.info("-- Board is %s (rev %s)",
                             IMURegisters.model_type(self.board_id.type),
@@ -135,7 +135,7 @@ class RegisterIO:
                 config = self.io_provider.read(IMURegisters.NAVX_REG_WHOAMI,
                                                IMURegisters.NAVX_REG_SENSOR_STATUS_H+1)
             except IOError as e:
-                logger.warn("Error reading configuration data, retrying (%s)", e)
+                logger.warning("Error reading configuration data, retrying (%s)", e)
                 success = False
                 Timer.delay(0.5)
             else:


### PR DESCRIPTION
- This changes all calls to `logger.warn()` to `logger.warning()`, as the former is a deprecated alias.
- This also rewrites `_create_wrapper()` in `magicbot.state_machine` and `robotpy_ext.autonomous.stateful_autonomous` to use `inspect.signature()` instead of the deprecated `inspect.getargspec()`.
  - `inspect.getfullargspec()` would use `inspect.Signature` anyway, so I rewrote it to use `inspect.signature()` for efficiency. It looked like it needed a rewrite anyway.