### PR TITLE
Injection tests and annotations fixes/improvements

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -458,7 +458,7 @@ class MagicRobot(wpilib.SampleRobot,
                 raise TypeError('Component %s has a non-type annotation on %s (%s); lone non-injection variable annotations are disallowed, did you want to assign a static variable?' %
                                 (cname, n, inject_type))
 
-            self._inject(n, inject_type, cname, component_type)
+            self._inject(n, inject_type, cname, component)
 
         # Iterate over static variables
         for n in dir(component):

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -440,11 +440,6 @@ class MagicRobot(wpilib.SampleRobot,
             if n.startswith('_'):
                 continue
 
-            # If the type is not actually a type, give a meaningful error
-            if not isinstance(inject_type, type):
-                raise TypeError('Component %s has a non-type annotation on %s (%s); lone non-injection variable annotations are disallowed, did you want to assign a static variable?' %
-                                (cname, n, inject_type))
-
             if hasattr(component_type, n):
                 attr = getattr(component_type, n)
                 # If the value given to the variable is an instance of a type and isn't a property
@@ -452,6 +447,11 @@ class MagicRobot(wpilib.SampleRobot,
                 if isinstance(attr, type) and not isinstance(attr, property):
                     raise ValueError("%s.%s has two type declarations" % (component_type.__name__, n))
                 continue
+
+            # If the type is not actually a type, give a meaningful error
+            if not isinstance(inject_type, type):
+                raise TypeError('Component %s has a non-type annotation on %s (%s); lone non-injection variable annotations are disallowed, did you want to assign a static variable?' %
+                                (cname, n, inject_type))
 
             self._inject(n, inject_type, cname, component_type)
 

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -493,7 +493,7 @@ class MagicRobot(wpilib.SampleRobot,
                              (cname, n, self, type(injectable), inject_type))
         # Perform injection
         setattr(component, n, injectable)
-        self.logger.debug("%s -> %s as %s.%s", injectable, cname, n)
+        self.logger.debug("-> %s as %s.%s", injectable, cname, n)
 
         # XXX
         #if is_autosend:

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -448,6 +448,10 @@ class MagicRobot(wpilib.SampleRobot,
                     raise ValueError("%s.%s has two type declarations" % (component_type.__name__, n))
                 continue
 
+            # If the class variable has been assigned in __init__, skip it
+            if hasattr(component, n):
+                continue
+
             # If the type is not actually a type, give a meaningful error
             if not isinstance(inject_type, type):
                 raise TypeError('Component %s has a non-type annotation on %s (%s); lone non-injection variable annotations are disallowed, did you want to assign a static variable?' %

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -365,6 +365,35 @@ class MagicRobot(wpilib.SampleRobot,
         # Identify all of the types, and create them
         cls = self.__class__
 
+        # - Iterate over class variables with type annotations
+        for m, ctyp in get_class_annotations(cls).items():
+            # Ignore private variables
+            if m.startswith('_'):
+                continue
+
+            if hasattr(cls, m):
+                attr = getattr(cls, m)
+                # If the value given to the variable is an instance of a type and isn't a property
+                # raise an error. No double declaring types, e.g foo: type = type
+                if isinstance(attr, type) and not isinstance(attr, property):
+                    raise ValueError("%s.%s has two type declarations" % (cls.__name__, m))
+                continue
+
+            # If the class variable has been assigned in __init__, skip it
+            if hasattr(self, m):
+                continue
+
+            # If the type is not actually a type, give a meaningful error
+            if not isinstance(ctyp, type):
+                raise TypeError('%s has a non-type annotation on %s (%s); lone non-injection variable annotations are disallowed, did you want to assign a static variable?' %
+                                (cls.__name__, m, ctyp))
+
+            component = self._create_component(m, ctyp)
+
+            # Store for later
+            components.append((m, component))
+
+        # - Iterate over set class variables
         for m in self.members:
             if m.startswith('_') or isinstance(getattr(cls, m, None), _TunableProperty):
                 continue
@@ -373,23 +402,10 @@ class MagicRobot(wpilib.SampleRobot,
             if not isinstance(ctyp, type):
                 continue
 
-            # Create instance, set it on self
-            component = ctyp()
-            setattr(self, m, component)
-
-            # Ensure that mandatory methods are there
-            if not hasattr(component, 'execute') or \
-               not callable(component.execute):
-                raise ValueError("Component %s (%s) must have a method named 'execute'" % (m, component))
-
-            # Automatically inject a logger object
-            component.logger = logging.getLogger(m)
-            component._Magicbot__autosend = {}
+            component = self._create_component(m, ctyp)
 
             # Store for later
             components.append((m, component))
-            
-            self.logger.info("-> %s (class: %s)", m, ctyp.__name__)
 
         # Collect attributes of this robot that are injectable
         self._injectables = {}
@@ -427,6 +443,23 @@ class MagicRobot(wpilib.SampleRobot,
         for cname, component in components:
             if hasattr(component, 'setup'):
                 component.setup()
+
+    def _create_component(self, name, ctyp):
+        # Create instance, set it on self
+        component = ctyp()
+        setattr(self, name, component)
+
+        # Ensure that mandatory methods are there
+        if not callable(getattr(component, 'execute', None)):
+            raise ValueError("Component %s (%s) must have a method named 'execute'" % (name, component))
+
+        # Automatically inject a logger object
+        component.logger = logging.getLogger(name)
+        component._Magicbot__autosend = {}
+
+        self.logger.info("-> %s (class: %s)", name, ctyp.__name__)
+
+        return component
     
     def _setup_vars(self, cname, component):
         

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -9,6 +9,7 @@ from robotpy_ext.misc import PreciseDelay
 from robotpy_ext.autonomous import AutonomousModeSelector
 
 from robotpy_ext.misc.orderedclass import OrderedClass
+from robotpy_ext.misc.annotations import get_class_annotations
 
 from networktables import NetworkTable
 
@@ -434,7 +435,7 @@ class MagicRobot(wpilib.SampleRobot,
         component_type = type(component)
         
         # Iterate over variables with type annotations
-        for n, inject_type in getattr(component, '__annotations__', {}).items():
+        for n, inject_type in get_class_annotations(component_type).items():
 
             # If the variable is private ignore it
             if n.startswith('_'):

--- a/robotpy_ext/misc/annotations.py
+++ b/robotpy_ext/misc/annotations.py
@@ -1,0 +1,6 @@
+def get_class_annotations(cls):
+    """Get variable annotations in a class, inheriting from superclasses."""
+    result = {}
+    for base in reversed(cls.__mro__):
+        result.update(getattr(base, '__annotations__', {}))
+    return result

--- a/tests/magicbot_annotation_tester.py
+++ b/tests/magicbot_annotation_tester.py
@@ -1,0 +1,121 @@
+import magicbot
+
+
+class Injectable:
+    def __init__(self, num):
+        self.num = num
+
+
+class DumbComponent:
+    def execute(self):
+        pass
+
+
+class Component1:
+    intvar: int
+    tupvar: tuple
+
+    injectable: Injectable
+
+    def execute(self):
+        pass
+
+
+class Component2:
+    tupvar: tuple
+
+    component1: Component1
+
+    def execute(self):
+        pass
+
+
+class SimpleBot(magicbot.MagicRobot):
+    intvar = 1
+    tupvar = 1, 2
+
+    component1: Component1
+    component2: Component2
+
+    def createObjects(self):
+        self.injectable = Injectable(42)
+
+
+class DuplicateComponent:
+    var: tuple
+    injectable: Injectable
+
+    def execute(self):
+        pass
+
+
+class MultilevelBot(magicbot.MagicRobot):
+    dup1: DuplicateComponent
+    dup1_var = 1, 2
+
+    dup2: DuplicateComponent
+    dup2_var = 3, 4
+
+    dup3: DuplicateComponent
+    dup3_var = 5, 6
+
+    def createObjects(self):
+        self.injectable = Injectable(42)
+
+
+class SuperComponent:
+    intvar: int
+
+    def execute(self):
+        pass
+
+
+class InheritedComponent(SuperComponent):
+    tupvar: tuple
+
+    def execute(self):
+        pass
+
+
+class InheritBot(magicbot.MagicRobot):
+    component: InheritedComponent
+
+    def createObjects(self):
+        self.intvar = 1
+        self.tupvar = 1, 2
+
+
+class BotBase(magicbot.MagicRobot):
+    component_a: DumbComponent
+
+    def createObjects(self):
+        pass
+
+
+class InheritedBot(BotBase):
+    component_b: DumbComponent
+
+
+class TypeHintedBot(magicbot.MagicRobot):
+    some_int: int = 1
+
+    component: DumbComponent
+
+    def createObjects(self):
+        pass
+
+
+class TypeHintedComponent:
+    injectable: Injectable
+
+    some_int: int = 1
+
+    def execute(self):
+        pass
+
+
+class TypeHintsBot(magicbot.MagicRobot):
+    component: TypeHintedComponent
+
+    def createObjects(self):
+        self.injectable = Injectable(42)

--- a/tests/test_magicbot_injection.py
+++ b/tests/test_magicbot_injection.py
@@ -105,3 +105,25 @@ def test_inherited_inject():
 
     assert bot.component.tupvar == (1, 2)
     assert bot.component.intvar == 1
+
+
+def test_botinherit_inject():
+    class Component:
+        def execute(self):
+            pass
+
+    class BotBase(magicbot.MagicRobot):
+        component_a = Component
+
+        def createObjects(self):
+            pass
+
+    class Bot(BotBase):
+        component_b = Component
+
+    bot = Bot()
+    bot.robotInit()
+
+    assert isinstance(bot.component_a, Component)
+    assert isinstance(bot.component_b, Component)
+    assert bot.component_a is not bot.component_b

--- a/tests/test_magicbot_injection.py
+++ b/tests/test_magicbot_injection.py
@@ -78,3 +78,30 @@ def test_multilevel_inject():
     assert bot.dup1.var == (1,2)
     assert bot.dup2.var == (3,4)
     assert bot.dup3.var == (5,6)
+
+
+def test_inherited_inject():
+    class SuperComponent:
+        intvar = int
+
+        def execute(self):
+            pass
+
+    class Component(SuperComponent):
+        tupvar = tuple
+
+        def execute(self):
+            pass
+
+    class Bot(magicbot.MagicRobot):
+        component = Component
+
+        def createObjects(self):
+            self.intvar = 1
+            self.tupvar = (1, 2)
+
+    bot = Bot()
+    bot.robotInit()
+
+    assert bot.component.tupvar == (1, 2)
+    assert bot.component.intvar == 1

--- a/tests/test_magicbot_injection.py
+++ b/tests/test_magicbot_injection.py
@@ -1,4 +1,4 @@
-
+import sys
 import magicbot
 
 class Injectable:
@@ -127,3 +127,69 @@ def test_botinherit_inject():
     assert isinstance(bot.component_a, Component)
     assert isinstance(bot.component_b, Component)
     assert bot.component_a is not bot.component_b
+
+
+# Variable annotations are a Python 3.6+ feature
+if sys.version_info >= (3, 6):
+    def test_simple_annotation_inject():
+        from magicbot_annotation_tester import SimpleBot, Injectable
+
+        bot = SimpleBot()
+        bot.robotInit()
+
+        assert bot.component1.intvar == 1
+        assert isinstance(bot.component1.injectable, Injectable)
+        assert bot.component1.injectable.num == 42
+
+        assert bot.component2.tupvar == (1, 2)
+        assert bot.component2.component1 is bot.component1
+
+    def test_multilevel_annotation_inject():
+        from magicbot_annotation_tester import MultilevelBot
+
+        bot = MultilevelBot()
+        bot.robotInit()
+
+        assert bot.dup1 is not bot.dup2
+        assert bot.dup1.var == (1, 2)
+        assert bot.dup2.var == (3, 4)
+        assert bot.dup3.var == (5, 6)
+
+    def test_inherited_annotation_inject():
+        from magicbot_annotation_tester import InheritBot
+
+        bot = InheritBot()
+        bot.robotInit()
+
+        assert bot.component.tupvar == (1, 2)
+        assert bot.component.intvar == 1
+
+    def test_botinherit_annotation_inject():
+        from magicbot_annotation_tester import InheritedBot, DumbComponent
+
+        bot = InheritedBot()
+        bot.robotInit()
+
+        assert isinstance(bot.component_a, DumbComponent)
+        assert isinstance(bot.component_b, DumbComponent)
+        assert bot.component_a is not bot.component_b
+
+    def test_typehintedbot():
+        from magicbot_annotation_tester import TypeHintedBot, DumbComponent
+
+        bot = TypeHintedBot()
+        bot.robotInit()
+
+        assert isinstance(bot.component, DumbComponent)
+        assert bot.some_int == 1
+
+    def test_typehints_inject():
+        from magicbot_annotation_tester import TypeHintsBot, TypeHintedComponent, Injectable
+
+        bot = TypeHintsBot()
+        bot.robotInit()
+
+        assert isinstance(bot.component, TypeHintedComponent)
+        assert bot.component.some_int == 1
+        assert isinstance(bot.component.injectable, Injectable)
+        assert bot.component.injectable.num == 42


### PR DESCRIPTION
- Add tests for injection inheritance.
- Fix injection to allow annotated and assigned variables to be skipped.
- Fix injection to allow for inheriting variable annotations when searching for injectables.
- Fix a `logger.debug()` call in `MagicRobot._inject()`.
- Fix injection to inject into instances when using variable annotations.
- Allow for using variable annotations to declare components.
- Add tests for using variable annotations for injection/component declaration.