### PR TITLE
Create Toggle

### DIFF
--- a/robotpy_ext/control/toggle.py
+++ b/robotpy_ext/control/toggle.py
@@ -1,0 +1,111 @@
+from _functools import partial
+from wpilib.timer import Timer
+
+
+class Toggle:
+    """Utility class for button toggle
+
+        Usage:
+
+        foo = Toggle(joystick, 3)
+
+        if foo:
+            toggleFunction()
+
+        if foo.on:
+            onToggle()
+
+        if foo.off:
+            offToggle()
+    """
+    class _SteadyDebounce:
+        '''
+            Similar to ButtonDebouncer, but the output stays steady for
+            the given periodic_filter. E.g, if you set the period to 2
+            and press the button, the value will return true for 2 seconds.
+
+            Steady debounce will return true for the given period, allowing it to be
+            used with Toggle
+        '''
+
+        def __init__(self, joystick, button, period=0.5):
+            '''
+            :param joystick:  Joystick object
+            :type  joystick:  :class:`wpilib.Joystick`
+            :param button: Number of button to retrieve
+            :type  button: int
+            :param period:    Period of time (in seconds) to wait before allowing new button
+                              presses. Defaults to 0.5 seconds.
+            :type  period:    float
+            '''
+            self.joystick = joystick
+            self.button = button
+
+            self.debounce_period = float(period)
+            self.latest = - self.debounce_period # Negative latest prevents get from returning true until joystick is presed for the first time
+            self.timer = Timer
+            self.enabled = False
+
+        def set_debounce_period(self, period):
+            '''Set number of seconds to hold return value'''
+            self.debounce_period = float(period)
+
+        def get(self):
+            '''Returns the value of the joystick button. Once the button is pressed,
+            the return value will be True until the time expires
+            '''
+
+            now = self.timer.getFPGATimestamp()
+            if now - self.latest < self.debounce_period:
+                return True
+
+            if self.joystick.getRawButton(self.button):
+                self.latest = now
+                return True
+            else:
+                return False
+
+    def __init__(self, joystick, button, debouncePeriod=None):
+        """
+        :param joystick: wpilib.Joystick that contains the button to toggle
+        :param button: Value of button that will act as toggle. Same value used in getRawButton()
+        """
+
+        if debouncePeriod is not None:
+            self.joystick = Toggle._SteadyDebounce(joystick, button, debouncePeriod)
+        else:
+            self.joystick = joystick
+            self.joystick.get = partial(self.joystick.getRawButton, button)
+
+        self.released = False
+        self.toggle = False
+        self.state = False
+
+    def get(self):
+        """
+         :return: State of toggle
+         :rtype: bool
+         """
+        current_state = self.joystick.get()
+
+        if current_state and not self.released:
+            self.released = True
+            self.toggle = not self.toggle
+            self.state = not self.state # Toggles between 1 and 0.
+
+        elif not current_state and self.released:
+            self.released = False
+
+        return self.toggle
+
+    @property
+    def on(self):
+        self.get()
+        return self.state
+
+    @property
+    def off(self):
+        self.get()
+        return not self.state
+
+    __bool__ = get

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -1,0 +1,44 @@
+from robotpy_ext.control.toggle import Toggle
+from robotpy_ext.misc.precise_delay import PreciseDelay
+class FakeJoystick:
+    def __init__(self):
+        self._pressed = False 
+    
+    def getRawButton(self, num):
+        return self._pressed
+    
+    def press(self):
+        self._pressed = True
+    
+    def release(self):
+        self._pressed = False
+    
+def test_toggle():
+    joystick = FakeJoystick()
+    toggleButton = Toggle(joystick, 1)
+    assert toggleButton.off
+    joystick.press()
+    assert toggleButton.on
+    joystick.release()
+    assert toggleButton.on
+    joystick.press()
+    assert toggleButton.off
+    joystick.release()
+    assert toggleButton.off
+
+
+def test_toggle_debounce():
+    delay = PreciseDelay(2.1)
+    joystick = FakeJoystick()
+    toggleButton = Toggle(joystick, 1, 2)
+    assert toggleButton.off
+    joystick.press()
+    assert toggleButton.on
+    joystick.release()
+    joystick.press()
+    joystick.release()
+    assert toggleButton.on
+    delay.wait()
+    assert toggleButton.on
+    joystick.press()
+    assert toggleButton.off


### PR DESCRIPTION
Like debounce, just another useful feature for buttons. I added Toggle.on and Toggle.off to remove boilerplate when only wanting to perform an action during one state

```
if toggle.on:
    toggleOnFoo()
```
vs

```
on = False
if toggle and not on:
    toggleOnFoo()
    on = True
if toggle and on:
    on = False
```


I also allowed the option of adding a debounce to the toggle. I had to create a new debounce because we want the value to remain true even if the joystick bounces, instead of returning true once, then false until the time expires