### PR TITLE
Further clean up, expose feedback decorator

### DIFF
--- a/magicbot/__init__.py
+++ b/magicbot/__init__.py
@@ -1,6 +1,6 @@
 
 from .magicrobot import MagicRobot
-from .magic_tunable import tunable
+from .magic_tunable import feedback, tunable
 from .magic_reset import will_reset_to
 
 from .state_machine import AutonomousStateMachine, StateMachine, default_state, state, timed_state


### PR DESCRIPTION
This moves the feedback decorator to the magicbot.magic_tunable module,
where it makes more sense to live.

This also exposes the feedback decorator, as it was never exported.

Add a hint in the docs to also see LiveWindow, as that may fit teams'
needs without the need for this.

Also delete the dead autosend code, as this is what it ended up being.

Finally, this cleans up and fixes a few gripes I had:

* The NetworkTables key used didn't match those of tunables.
* Decorating methods in your robot class with feedback didn't work.
* The decorator required the use of an extra set of parentheses.

@virtuald, this is a breaking change, but feedback was never actually
documented, so is pulling this in and releasing a v2018.1.0 fine?