### PR TITLE
Miscellaneous changes related to magicbot test mode

### DIFF
--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -141,7 +141,7 @@ def feedback(f=None, *, key: str = None):
     * A component: ``/components/COMPONENTNAME/VARNAME``
     * Your main robot class: ``/robot/VARNAME``
 
-    The NetworkTables value will be auto-updated in all modes (except test mode).
+    The NetworkTables value will be auto-updated in all modes.
 
     .. warning:: The function should only act as a getter, and must not
                  take any arguments (other than self).

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -162,8 +162,11 @@ class MagicRobot(wpilib.SampleRobot,
             This function gets called last in each mode.
             You may use it for any code you need to run
             during all modes of the robot (e.g NetworkTables updates)
+
+            The default implementation will update SmartDashboard and LiveWindow.
         """
-        pass
+        wpilib.SmartDashboard.updateValues()
+        wpilib.LiveWindow.updateValues()
 
     def onException(self, forceReport=False):
         '''
@@ -256,6 +259,7 @@ class MagicRobot(wpilib.SampleRobot,
         
         self.__nt.putString('mode', 'auto')
         self.__nt.putBoolean('is_ds_attached', self.ds.isDSAttached())
+        wpilib.LiveWindow.setEnabled(False)
 
         self._on_mode_enable_components()
 
@@ -277,6 +281,7 @@ class MagicRobot(wpilib.SampleRobot,
         
         self.__nt.putString('mode', 'disabled')
         ds_attached = None
+        wpilib.LiveWindow.setEnabled(False)
 
         delay = PreciseDelay(self.control_loop_wait_time)
 
@@ -314,6 +319,7 @@ class MagicRobot(wpilib.SampleRobot,
         # don't need to update this during teleop -- presumably will switch
         # modes when ds is no longer attached
         self.__nt.putBoolean('is_ds_attached', self.ds.isDSAttached())
+        wpilib.LiveWindow.setEnabled(False)
 
         delay = PreciseDelay(self.control_loop_wait_time)
 
@@ -345,9 +351,9 @@ class MagicRobot(wpilib.SampleRobot,
         
         self.__nt.putString('mode', 'test')
         self.__nt.putBoolean('is_ds_attached', self.ds.isDSAttached())
+        wpilib.LiveWindow.setEnabled(True)
         
         while self.isTest() and self.isEnabled():
-            wpilib.LiveWindow.run()
             self._update_feedback()
             self.robotPeriodic()
             wpilib.Timer.delay(self.control_loop_wait_time)

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -348,6 +348,8 @@ class MagicRobot(wpilib.SampleRobot,
         
         while self.isTest() and self.isEnabled():
             wpilib.LiveWindow.run()
+            self._update_feedback()
+            self.robotPeriodic()
             wpilib.Timer.delay(.01)
 
     def _on_mode_enable_components(self):

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -350,7 +350,7 @@ class MagicRobot(wpilib.SampleRobot,
             wpilib.LiveWindow.run()
             self._update_feedback()
             self.robotPeriodic()
-            wpilib.Timer.delay(.01)
+            wpilib.Timer.delay(self.control_loop_wait_time)
 
     def _on_mode_enable_components(self):
         # initialize things


### PR DESCRIPTION
* Ensure feedbacks are updated and robotPeriodic is called in test mode.
* Add updating SmartDashboard and LiveWindow to the default robotPeriodic.

I'm thinking we should also add testInit and testPeriodic methods to closer align magicbot to TimedRobot. Thoughts?