### PR TITLE
Add NotifierDelay

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -295,30 +295,26 @@ class MagicRobot(wpilib.SampleRobot,
         ds_attached = None
         wpilib.LiveWindow.setEnabled(False)
 
-        delay = NotifierDelay(self.control_loop_wait_time)
-
         self._on_mode_disable_components()
         try:
             self.disabledInit()
         except:
             self.onException(forceReport=True)
 
-        while self.isDisabled():
-            
-            if ds_attached != self.ds.isDSAttached():
-                ds_attached = not ds_attached
-                self.__nt.putBoolean('is_ds_attached', ds_attached)
-            
-            try:
-                self.disabledPeriodic()
-            except:
-                self.onException()
+        with NotifierDelay(self.control_loop_wait_time) as delay:
+            while self.isDisabled():
+                if ds_attached != self.ds.isDSAttached():
+                    ds_attached = not ds_attached
+                    self.__nt.putBoolean('is_ds_attached', ds_attached)
 
-            self._update_feedback()
-            self.robotPeriodic()
-            delay.wait()
+                try:
+                    self.disabledPeriodic()
+                except:
+                    self.onException()
 
-        delay.free()
+                self._update_feedback()
+                self.robotPeriodic()
+                delay.wait()
 
     def operatorControl(self):
         """
@@ -335,8 +331,6 @@ class MagicRobot(wpilib.SampleRobot,
         self.__nt.putBoolean('is_ds_attached', self.ds.isDSAttached())
         wpilib.LiveWindow.setEnabled(False)
 
-        delay = NotifierDelay(self.control_loop_wait_time)
-
         # initialize things
         self._on_mode_enable_components()
 
@@ -345,20 +339,19 @@ class MagicRobot(wpilib.SampleRobot,
         except:
             self.onException(forceReport=True)
 
-        while self.isOperatorControl() and self.isEnabled():
-            
-            try:
-                self.teleopPeriodic()
-            except:
-                self.onException()
+        with NotifierDelay(self.control_loop_wait_time) as delay:
+            while self.isOperatorControl() and self.isEnabled():
+                try:
+                    self.teleopPeriodic()
+                except:
+                    self.onException()
 
-            self._execute_components()
-            self._update_feedback()
-            self.robotPeriodic()
+                self._execute_components()
+                self._update_feedback()
+                self.robotPeriodic()
 
-            delay.wait()
+                delay.wait()
 
-        delay.free()
         self._on_mode_disable_components()
 
     def test(self):
@@ -368,24 +361,21 @@ class MagicRobot(wpilib.SampleRobot,
         self.__nt.putBoolean('is_ds_attached', self.ds.isDSAttached())
         wpilib.LiveWindow.setEnabled(True)
 
-        delay = NotifierDelay(self.control_loop_wait_time)
-
         try:
             self.testInit()
         except:
             self.onException(forceReport=True)
-        
-        while self.isTest() and self.isEnabled():
-            try:
-                self.testPeriodic()
-            except:
-                self.onException()
 
-            self._update_feedback()
-            self.robotPeriodic()
-            delay.wait()
+        with NotifierDelay(self.control_loop_wait_time) as delay:
+            while self.isTest() and self.isEnabled():
+                try:
+                    self.testPeriodic()
+                except:
+                    self.onException()
 
-        delay.free()
+                self._update_feedback()
+                self.robotPeriodic()
+                delay.wait()
 
     def _on_mode_enable_components(self):
         # initialize things

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -5,7 +5,7 @@ import logging
 
 import wpilib
 
-from robotpy_ext.misc import PreciseDelay
+from robotpy_ext.misc import NotifierDelay
 from robotpy_ext.autonomous import AutonomousModeSelector
 
 from robotpy_ext.misc.orderedclass import OrderedClass
@@ -295,7 +295,7 @@ class MagicRobot(wpilib.SampleRobot,
         ds_attached = None
         wpilib.LiveWindow.setEnabled(False)
 
-        delay = PreciseDelay(self.control_loop_wait_time)
+        delay = NotifierDelay(self.control_loop_wait_time)
 
         self._on_mode_disable_components()
         try:
@@ -318,6 +318,8 @@ class MagicRobot(wpilib.SampleRobot,
             self.robotPeriodic()
             delay.wait()
 
+        delay.free()
+
     def operatorControl(self):
         """
             This function is called in teleoperated mode. You should not
@@ -333,7 +335,7 @@ class MagicRobot(wpilib.SampleRobot,
         self.__nt.putBoolean('is_ds_attached', self.ds.isDSAttached())
         wpilib.LiveWindow.setEnabled(False)
 
-        delay = PreciseDelay(self.control_loop_wait_time)
+        delay = NotifierDelay(self.control_loop_wait_time)
 
         # initialize things
         self._on_mode_enable_components()
@@ -356,6 +358,7 @@ class MagicRobot(wpilib.SampleRobot,
 
             delay.wait()
 
+        delay.free()
         self._on_mode_disable_components()
 
     def test(self):
@@ -364,6 +367,8 @@ class MagicRobot(wpilib.SampleRobot,
         self.__nt.putString('mode', 'test')
         self.__nt.putBoolean('is_ds_attached', self.ds.isDSAttached())
         wpilib.LiveWindow.setEnabled(True)
+
+        delay = NotifierDelay(self.control_loop_wait_time)
 
         try:
             self.testInit()
@@ -378,7 +383,9 @@ class MagicRobot(wpilib.SampleRobot,
 
             self._update_feedback()
             self.robotPeriodic()
-            wpilib.Timer.delay(self.control_loop_wait_time)
+            delay.wait()
+
+        delay.free()
 
     def _on_mode_enable_components(self):
         # initialize things

--- a/robotpy_ext/autonomous/selector.py
+++ b/robotpy_ext/autonomous/selector.py
@@ -226,24 +226,22 @@ class AutonomousModeSelector:
         #
         # Autonomous control loop
         #
-        
-        delay = NotifierDelay(control_loop_wait_time)
-        
-        while self.ds.isAutonomous() and self.ds.isEnabled():
- 
-            try:            
-                self._on_iteration(timer.get())
-            except:
-                on_exception()
-            
-            if isinstance(iter_fn, (list, tuple)):
-                for fn in iter_fn:
-                    fn()
-            else:
-                iter_fn()
-             
-            delay.wait()
-            
+
+        with NotifierDelay(control_loop_wait_time) as delay:
+            while self.ds.isAutonomous() and self.ds.isEnabled():
+                try:
+                    self._on_iteration(timer.get())
+                except:
+                    on_exception()
+
+                if isinstance(iter_fn, (list, tuple)):
+                    for fn in iter_fn:
+                        fn()
+                else:
+                    iter_fn()
+
+                delay.wait()
+
         #
         # Done with autonomous, finish up
         #

--- a/robotpy_ext/autonomous/selector.py
+++ b/robotpy_ext/autonomous/selector.py
@@ -7,7 +7,7 @@ import os
 import logging
 logger = logging.getLogger('autonomous')
 
-from ..misc.precise_delay import PreciseDelay
+from ..misc.precise_delay import NotifierDelay
 
 import wpilib
 
@@ -227,7 +227,7 @@ class AutonomousModeSelector:
         # Autonomous control loop
         #
         
-        delay = PreciseDelay(control_loop_wait_time)
+        delay = NotifierDelay(control_loop_wait_time)
         
         while self.ds.isAutonomous() and self.ds.isEnabled():
  
@@ -254,6 +254,7 @@ class AutonomousModeSelector:
             on_exception(forceReport=True)
             
         logger.info("Autonomous mode ended")
+        delay.free()
         
     #
     #   Internal methods used to implement autonomous mode switching, and

--- a/robotpy_ext/misc/__init__.py
+++ b/robotpy_ext/misc/__init__.py
@@ -1,3 +1,3 @@
 
-from .precise_delay import PreciseDelay
+from .precise_delay import NotifierDelay, PreciseDelay
 from .periodic_filter import PeriodicFilter


### PR DESCRIPTION
Add a version of PreciseDelay that uses FPGA interrupts instead of busy waiting.

Caveat: Users must manually clean up the notifier handle once this object is no longer in use.

Also change our usage of PreciseDelay to NotifierDelay.

In my brief tests, this also reduces CPU usage of the magicbot-simple example in the simulator to about 1/4 of what it was using with PreciseDelay :)