### PR TITLE
Fix AutonomousModeSelector delay freeing

### DIFF
--- a/robotpy_ext/autonomous/selector.py
+++ b/robotpy_ext/autonomous/selector.py
@@ -252,8 +252,7 @@ class AutonomousModeSelector:
             on_exception(forceReport=True)
             
         logger.info("Autonomous mode ended")
-        delay.free()
-        
+
     #
     #   Internal methods used to implement autonomous mode switching, and
     #   are called automatically


### PR DESCRIPTION
This fixes the AttributeError at the end of autonomous with the PreciseDelay hack.