### PR TITLE
Call setup() on autonomous modes, fixing #19

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -503,7 +503,6 @@ class MagicRobot(wpilib.SampleRobot,
             if hasattr(mode, 'setup'):
                 mode.setup()
 
-
     def _create_component(self, name, ctyp):
         # Create instance, set it on self
         component = ctyp()

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -500,7 +500,7 @@ class MagicRobot(wpilib.SampleRobot,
 
         # Call setup functions for autonomous modes
         for mode in self._automodes.modes.values():
-            if hasattr(component, 'setup'):
+            if hasattr(mode, 'setup'):
                 mode.setup()
 
 

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -498,6 +498,12 @@ class MagicRobot(wpilib.SampleRobot,
             if hasattr(component, 'setup'):
                 component.setup()
 
+        # Call setup functions for autonomous modes
+        for mode in self._automodes.modes.values():
+            if hasattr(component, 'setup'):
+                mode.setup()
+
+
     def _create_component(self, name, ctyp):
         # Create instance, set it on self
         component = ctyp()


### PR DESCRIPTION
This allows accessing magic injected variables from autonomous modes during initialization