### PR TITLE
Ensure LICENSE is distributed in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+# Include the license file in wheels.
+license_file = LICENSE


### PR DESCRIPTION
As it turns out, the LICENSE is distributed in the sdist due to a lack of MANIFEST.in.