### PR TITLE
Fix periodic filter

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -4,7 +4,7 @@ import logging
 
 import wpilib
 
-from robotpy_ext.misc import NotifierDelay
+from robotpy_ext.misc import NotifierDelay, PeriodicFilter
 from robotpy_ext.autonomous import AutonomousModeSelector
 
 from robotpy_ext.misc.orderedclass import OrderedClass
@@ -640,6 +640,9 @@ class MagicRobot(wpilib.SampleRobot, metaclass=OrderedClass):
         for component in self._components:
             try:
                 component.execute()
+                for f in component.logger.filters:
+                    if isinstance(f, PeriodicFilter):
+                        f.refresh()
             except:
                 self.onException()
 

--- a/robotpy_ext/misc/periodic_filter.py
+++ b/robotpy_ext/misc/periodic_filter.py
@@ -17,14 +17,18 @@ class PeriodicFilter:
 
                 def setup(self):
                     # Set period to 3 seconds, set bypass_level to WARN
-                    self.logger.addFilter(PeriodicFilter(3, bypass_level=logging.WARN))
+                    self.filter = PeriodicFilter(3, bypass_level=logging.WARN)
+                    self.logger.addFilter(filter)
 
                 def execute(self):
-                    # This message will be printed once every three seconds
+                    # These messages will be printed once every three seconds
                     self.logger.info('Component1 Executing')
+                    self.logger.debug('Here are some values...')
 
                     # This message will be printed out every loop
                     self.logger.warn("Uh oh, this shouldn't have happened...")
+
+                    self.filter.refresh() # Not needed when using magicbot framework
         
     """
 
@@ -41,10 +45,9 @@ class PeriodicFilter:
 
     def filter(self, record):
         """Performs filtering action for logger"""
-        self._refresh_logger()
         return self._loggingLoop or record.levelno >= self._bypass_level
 
-    def _refresh_logger(self):
+    def refresh(self):
         """Determine if the log wait period has passed"""
         now = time.monotonic()
         self._loggingLoop = False


### PR DESCRIPTION
Due to not enough testing, I didn't catch this until now. By having the filter method refresh the timing, you could only log *once* to the logger each loop. 


