### PR TITLE
magicbot: Collect component feedbacks after setup

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -494,7 +494,6 @@ class MagicRobot(wpilib.SampleRobot, metaclass=OrderedClass):
         for cname, component in components:
             self._components.append(component)
             setup_tunables(component, cname, "components")
-            self._feedbacks += collect_feedbacks(component, cname, "components")
             self._setup_vars(cname, component)
             self._setup_reset_vars(component)
 
@@ -510,8 +509,11 @@ class MagicRobot(wpilib.SampleRobot, metaclass=OrderedClass):
 
         # Call setup functions for components
         for cname, component in components:
-            if hasattr(component, "setup"):
-                component.setup()
+            setup = getattr(component, "setup", None)
+            if setup is not None:
+                setup()
+            # ... and grab all the feedback methods
+            self._feedbacks += collect_feedbacks(component, cname, "components")
 
         # Call setup functions for autonomous modes
         for mode in self._automodes.modes.values():


### PR DESCRIPTION
Avoids exceptions in properties when uninitialised being caught by
debuggers, such as VS Code when breaking on all exceptions.

(The inspect module catches exceptions when getting attributes.)