### PR TITLE
magicbot: Refactor tunable to be a descriptor

### DIFF
--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import warnings
 from typing import Generic, Optional, TypeVar
 
 from networktables import NetworkTables
@@ -73,9 +74,12 @@ class tunable(Generic[V]):
         default: V,
         *,
         writeDefault: bool = True,
-        subtable: Optional[str] = None
-        # , doc: Optional[str] = None
+        subtable: Optional[str] = None,
+        doc=None
     ) -> None:
+        if doc is not None:
+            warnings.warn("tunable no longer uses the doc argument", stacklevel=2)
+
         self._ntdefault = default
         self._ntsubtable = subtable
         self._ntwritedefault = writeDefault

--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -1,19 +1,14 @@
 import functools
 import inspect
+from typing import Generic, Optional, TypeVar
 
 from networktables import NetworkTables
 from ntcore.value import Value
 
-# Only used as a marker
-class _TunableProperty(property):
-    pass
+V = TypeVar("V")
 
 
-class _AutosendProperty(_TunableProperty):
-    pass
-
-
-def tunable(default, *, writeDefault=True, subtable=None, doc=None):
+class tunable(Generic[V]):
     """
         This allows you to define simple properties that allow you to easily
         communicate with other programs via NetworkTables.
@@ -23,9 +18,9 @@ def tunable(default, *, writeDefault=True, subtable=None, doc=None):
         
             class MyRobot(magicbot.MagicRobot):
             
-                my_component = MyComponent
+                my_component: MyComponent
         
-            ... 
+            ...
             
             from magicbot import tunable
         
@@ -33,8 +28,7 @@ def tunable(default, *, writeDefault=True, subtable=None, doc=None):
         
                 # define the tunable property
                 foo = tunable(True)
-    
-    
+
                 def execute(self):
                 
                     # set the variable
@@ -65,33 +59,48 @@ def tunable(default, *, writeDefault=True, subtable=None, doc=None):
     # the name of the key is related to the name of the variable name in the
     # robot class
 
-    nt = NetworkTables
-    mkv = Value.getFactory(default)
+    __slots__ = (
+        "_ntdefault",
+        "_ntsubtable",
+        "_ntwritedefault",
+        # "__doc__",
+        "_mkv",
+        "_nt",
+    )
 
-    def _get(self):
-        return getattr(self, prop._ntattr).value
+    def __init__(
+        self,
+        default: V,
+        *,
+        writeDefault: bool = True,
+        subtable: Optional[str] = None
+        # , doc: Optional[str] = None
+    ) -> None:
+        self._ntdefault = default
+        self._ntsubtable = subtable
+        self._ntwritedefault = writeDefault
+        # self.__doc__ = doc
 
-    def _set(self, value):
-        v = getattr(self, prop._ntattr)
-        nt._api.setEntryValueById(v._local_id, mkv(value))
+        self._mkv = Value.getFactory(default)
+        self._nt = NetworkTables
 
-    prop = _TunableProperty(fget=_get, fset=_set, doc=doc)
-    prop._ntdefault = default
-    prop._ntsubtable = subtable
-    prop._ntwritedefault = writeDefault
+    def __get__(self, instance, owner) -> V:
+        if instance is not None:
+            return instance._tunables[self].value
+        return self
 
-    return prop
+    def __set__(self, instance, value) -> None:
+        v = instance._tunables[self]
+        self._nt._api.setEntryValueById(v._local_id, self._mkv(value))
 
 
-def setup_tunables(component, cname, prefix="components"):
+def setup_tunables(component, cname: str, prefix: Optional[str] = "components") -> None:
     """
         Connects the tunables on an object to NetworkTables.
 
         :param component:   Component object
         :param cname:       Name of component
-        :type cname: str
         :param prefix:      Prefix to use, or no prefix if None
-        :type prefix: str    
     
         .. note:: This is not needed in normal use, only useful
                   for testing
@@ -104,12 +113,14 @@ def setup_tunables(component, cname, prefix="components"):
     else:
         prefix = "/%s/%s" % (prefix, cname)
 
+    tunables = {}
+
     for n in dir(cls):
         if n.startswith("_"):
             continue
 
         prop = getattr(cls, n)
-        if not isinstance(prop, _TunableProperty):
+        if not isinstance(prop, tunable):
             continue
 
         if prop._ntsubtable:
@@ -117,14 +128,12 @@ def setup_tunables(component, cname, prefix="components"):
         else:
             key = "%s/%s" % (prefix, n)
 
-        ntattr = "_Tunable__%s" % n
-
         ntvalue = NetworkTables.getGlobalAutoUpdateValue(
             key, prop._ntdefault, prop._ntwritedefault
         )
-        # double indirection
-        setattr(component, ntattr, ntvalue)
-        prop._ntattr = ntattr
+        tunables[prop] = ntvalue
+
+    component._tunables = tunables
 
 
 def feedback(f=None, *, key: str = None):

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -13,7 +13,7 @@ from robotpy_ext.misc import NotifierDelay
 from robotpy_ext.misc.orderedclass import OrderedClass
 from robotpy_ext.misc.annotations import get_class_annotations
 
-from .magic_tunable import setup_tunables, _TunableProperty, collect_feedbacks
+from .magic_tunable import setup_tunables, tunable, collect_feedbacks
 from .magic_reset import will_reset_to
 
 __all__ = ["MagicRobot"]
@@ -514,7 +514,7 @@ class MagicRobot(wpilib.SampleRobot, metaclass=OrderedClass):
 
         # - Iterate over set class variables
         for m in self.members:
-            if m.startswith("_") or isinstance(getattr(cls, m, None), _TunableProperty):
+            if m.startswith("_") or isinstance(getattr(cls, m, None), tunable):
                 continue
 
             ctyp = getattr(self, m)
@@ -533,7 +533,7 @@ class MagicRobot(wpilib.SampleRobot, metaclass=OrderedClass):
             if (
                 n.startswith("_")
                 or n in self._exclude_from_injection
-                or isinstance(getattr(cls, n, None), _TunableProperty)
+                or isinstance(getattr(cls, n, None), tunable)
             ):
                 continue
 


### PR DESCRIPTION
This refactors tunable to be a single descriptor class rather than using
closures and properties, and uses slightly less indirection.

Brief testing shows that this improves performance (ever so slightly).

**Breaking change**: This removes the `doc` argument to tunable.