### PR TITLE
Remove Python 3.5 and add 3.8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: required
 dist: xenial
 
 python:
+  - "3.8"
   - "3.7"
   - "3.6"
-  - "3.5"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Based on robotpy/robotpy-wpilib#606