### PR TITLE
Remove Python 3.5 and add 3.7, 3.8 Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,9 @@ setup(
         "Intended Audience :: Education",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering",
     ],
 )


### PR DESCRIPTION
Based on robotpy/robotpy-wpilib#606