### PR TITLE
magicbot: Fix will_reset_to setup

### DIFF
--- a/magicbot/magic_reset.py
+++ b/magicbot/magic_reset.py
@@ -1,3 +1,6 @@
+from typing import Any, Dict
+
+
 class will_reset_to:
     """
         This marker indicates that this variable on a component will
@@ -30,3 +33,20 @@ class will_reset_to:
 
     def __init__(self, default):
         self.default = default
+
+
+def collect_resets(cls: type) -> Dict[str, Any]:
+    """
+    Get all the ``will_reset_to`` variables and their values from a class.
+
+    .. note:: This isn't useful for normal use.
+    """
+
+    result = {}
+
+    for n in dir(cls):
+        v = getattr(cls, n)
+        if isinstance(v, will_reset_to):
+            result[n] = v.default
+
+    return result

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -15,7 +15,7 @@ from robotpy_ext.misc import NotifierDelay
 from robotpy_ext.misc.simple_watchdog import SimpleWatchdog
 
 from .magic_tunable import setup_tunables, tunable, collect_feedbacks
-from .magic_reset import will_reset_to
+from .magic_reset import collect_resets
 
 __all__ = ["MagicRobot"]
 
@@ -700,15 +700,7 @@ class MagicRobot(wpilib._wpilib.RobotBaseUser):
         self.logger.debug("-> %s as %s.%s", injectable, cname, n)
 
     def _setup_reset_vars(self, component):
-        reset_dict = {}
-
-        for n in dir(component):
-            if isinstance(getattr(type(component), n, True), property):
-                continue
-
-            a = getattr(component, n, None)
-            if isinstance(a, will_reset_to):
-                reset_dict[n] = a.default
+        reset_dict = collect_resets(type(component))
 
         if reset_dict:
             component.__dict__.update(reset_dict)


### PR DESCRIPTION
This fixes tunables breaking the setup.

This breaks the undocumented feature that creating a `will_reset_to` in
the constructor worked, however I suspect we don't actually want this.