### PR TITLE
magicbot: Add type stub for magic_reset

### DIFF
--- a/magicbot/magic_reset.pyi
+++ b/magicbot/magic_reset.pyi
@@ -1,0 +1,14 @@
+from typing import Any, Dict, Generic, TypeVar, overload
+
+V = TypeVar("V")
+
+class will_reset_to(Generic[V]):
+    def __init__(self, default: V) -> None: ...
+    # we don't really have __get__, but this makes code in methods using these
+    # to type-check, whilst giving correct behaviour for code at the class level
+    @overload
+    def __get__(self, instance: None, owner=None) -> will_reset_to: ...
+    @overload
+    def __get__(self, instance, owner=None) -> V: ...
+
+def collect_resets(cls: type) -> Dict[str, Any]: ...

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     keywords="frc first robotics",
     install_requires=["pynetworktables>=2020.0.0", "wpilib>=2020.2.2.1,<2021.0.0"],
     packages=find_packages(),
+    package_data={"magicbot": ["py.typed", "__init__.pyi"]},
     license="BSD",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This makes user code type-check without paying any runtime cost,
with the caveat that this doesn't behave correctly only in `__init__`.