### PR TITLE
magicbot: Catch invalid state names even earlier

### DIFF
--- a/magicbot/state_machine.py
+++ b/magicbot/state_machine.py
@@ -42,11 +42,16 @@ class _State:
         duration: Optional[float] = None,
         is_default: bool = False,
     ) -> None:
+        name = f.__name__
+
+        # Can't define states that are named the same as things in the
+        # base class, will cause issues. Catch it early.
+        if hasattr(StateMachine, name):
+            raise InvalidStateName(f"cannot have a state named '{name}'")
+
         # inspect the args, provide a correct call implementation
         allowed_args = "self", "tm", "state_tm", "initial_call"
         sig = inspect.signature(f)
-        name = f.__name__
-
         args = []
         invalid_args = []
         for i, arg in enumerate(sig.parameters.values()):
@@ -98,11 +103,6 @@ class _State:
 
         if not issubclass(owner, StateMachine):
             raise TypeError(f"magicbot state {name} defined in non-StateMachine")
-
-        # Can't define states that are named the same as things in the
-        # base class, will cause issues. Catch it early.
-        if hasattr(StateMachine, name):
-            raise InvalidStateName(f"cannot have a state named '{name}'")
 
         # make durations tunable
         if self.duration is not None:

--- a/tests/test_magicbot_sm.py
+++ b/tests/test_magicbot_sm.py
@@ -380,14 +380,12 @@ def test_mixup():
 
 
 def test_forbidden_state_names():
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(InvalidStateName):
 
         class _SM(StateMachine):
             @state
             def done(self):
                 pass
-
-    assert isinstance(exc_info.value.__cause__, InvalidStateName)
 
 
 def test_mixins():


### PR DESCRIPTION
Since we now guarantee that state names match their function names, we
can now catch this at decoration time rather than class creation time.