### PR TITLE
docs: Fix module index

### DIFF
--- a/docs/magicbot.rst
+++ b/docs/magicbot.rst
@@ -4,6 +4,8 @@
 magicbot module
 ----------------
 
+.. module:: magicbot
+
 .. automodule:: magicbot.magicrobot
     :members:
     :exclude-members: autonomous, disabled, members, operatorControl, robotInit, test

--- a/docs/robotpy_ext.autonomous.rst
+++ b/docs/robotpy_ext.autonomous.rst
@@ -1,6 +1,8 @@
 robotpy_ext.autonomous package
 ==============================
 
+.. module:: robotpy_ext.autonomous
+
 robotpy_ext.autonomous.selector module
 --------------------------------------
 

--- a/docs/robotpy_ext.common_drivers.rst
+++ b/docs/robotpy_ext.common_drivers.rst
@@ -1,6 +1,8 @@
 robotpy_ext.common_drivers package
 ==================================
 
+.. module:: robotpy_ext.common_drivers
+
 robotpy_ext.common_drivers.distance_sensors module
 --------------------------------------------------
 

--- a/docs/robotpy_ext.control.rst
+++ b/docs/robotpy_ext.control.rst
@@ -1,6 +1,8 @@
 robotpy_ext.control package
 ===========================
 
+.. module:: robotpy_ext.control
+
 robotpy_ext.control.button_debouncer module
 -------------------------------------------
 

--- a/docs/robotpy_ext.misc.rst
+++ b/docs/robotpy_ext.misc.rst
@@ -1,6 +1,8 @@
 robotpy_ext.misc package
 ========================
 
+.. module:: robotpy_ext.misc
+
 robotpy_ext.misc.asyncio_policy module
 --------------------------------------
 


### PR DESCRIPTION
Fixes the missing links in https://robotpy.readthedocs.io/projects/utilities/en/stable/py-modindex.html