### PR TITLE
Fix magic_reset type stub

### DIFF
--- a/magicbot/magic_reset.pyi
+++ b/magicbot/magic_reset.pyi
@@ -1,8 +1,10 @@
 from typing import Any, Generic, TypeVar, overload
 
-_V = TypeVar("V")
+_V = TypeVar("_V")
 
 class will_reset_to(Generic[_V]):
+    default: _V
+
     def __init__(self, default: _V) -> None: ...
     # we don't really have __get__, but this makes code in methods using these
     # to type-check, whilst giving correct behaviour for code at the class level


### PR DESCRIPTION
- Forgot to fix the TypeVar name - fixes mypy breaking on `will_reset_to` value usage
- Type hint the `default` field