### PR TITLE
state_machine: Add type hints

### DIFF
--- a/magicbot/state_machine.py
+++ b/magicbot/state_machine.py
@@ -148,13 +148,12 @@ class _StateData:
 
 
 def timed_state(
-    f: Optional[Callable] = None,
     *,
     duration: float,
-    next_state=None,
+    next_state: Optional[StateRef] = None,
     first: bool = False,
     must_finish: bool = False,
-):
+) -> Callable[[StateMethod], _State]:
     """
     If this decorator is applied to a function in an object that inherits
     from :class:`.StateMachine`, it indicates that the function
@@ -183,20 +182,15 @@ def timed_state(
                         regardless of whether this is set.
     """
 
-    if f is None:
-        return functools.partial(
-            timed_state,
-            duration=duration,
-            next_state=next_state,
-            first=first,
-            must_finish=must_finish,
-        )
+    def decorator(f: StateMethod) -> _State:
 
-    wrapper = _State(f, first, must_finish, duration=duration)
+        wrapper = _State(f, first, must_finish, duration=duration)
 
-    wrapper.next_state = next_state
+        wrapper.next_state = next_state
 
-    return wrapper
+        return wrapper
+
+    return decorator
 
 
 def state(f=None, *, first: bool = False, must_finish: bool = False):

--- a/magicbot/state_machine.py
+++ b/magicbot/state_machine.py
@@ -469,24 +469,28 @@ class StateMachine:
         self.__start = 0
 
     @property
-    def is_executing(self):
+    def is_executing(self) -> bool:
         """:returns: True if the state machine is executing states"""
         # return self.__state is not None
         return self.__engaged
 
-    def on_enable(self):
+    def on_enable(self) -> None:
         """
         magicbot component API: called when autonomous/teleop is enabled
         """
         pass
 
-    def on_disable(self):
+    def on_disable(self) -> None:
         """
         magicbot component API: called when autonomous/teleop is disabled
         """
         self.done()
 
-    def engage(self, initial_state=None, force=False):
+    def engage(
+        self,
+        initial_state: Optional[StateRef] = None,
+        force: bool = False,
+    ) -> None:
         """
         This signals that you want the state machine to execute its
         states.
@@ -505,7 +509,7 @@ class StateMachine:
             else:
                 self.next_state(self.__first)
 
-    def next_state(self, state):
+    def next_state(self, state: StateRef) -> None:
         """Call this function to transition to the next state
 
         :param state: Name of the state to transition to
@@ -521,7 +525,7 @@ class StateMachine:
 
         self.__state = state_data
 
-    def next_state_now(self, state):
+    def next_state_now(self, state: StateRef) -> None:
         """Call this function to transition to the next state, and call the next
         state function immediately. Prefer to use :meth:`next_state` instead.
 
@@ -533,7 +537,7 @@ class StateMachine:
         # TODO: may want to do this differently?
         self.execute()
 
-    def done(self):
+    def done(self) -> None:
         """Call this function to end execution of the state machine.
 
         This function will always be called when a state machine ends. Even if
@@ -550,7 +554,7 @@ class StateMachine:
         self.__engaged = False
         self.current_state = ""
 
-    def execute(self):
+    def execute(self) -> None:
         """
         magicbot component API: This is called on each iteration of the
         control loop. Most of the time, you will not want to override
@@ -648,11 +652,11 @@ class AutonomousStateMachine(StateMachine):
 
     VERBOSE_LOGGING = True
 
-    def on_enable(self):
+    def on_enable(self) -> None:
         super().on_enable()
         self.__engaged = True
 
-    def on_iteration(self, tm):
+    def on_iteration(self, tm: float) -> None:
         # TODO, remove the on_iteration function in 2017?
 
         # Only engage the state machine until its execution finishes, otherwise
@@ -667,7 +671,7 @@ class AutonomousStateMachine(StateMachine):
             self.execute()
             self.__engaged = self.is_executing
 
-    def done(self):
+    def done(self) -> None:
         super().done()
         self._StateMachine__should_engage = False
         self.__engaged = False

--- a/magicbot/state_machine.py
+++ b/magicbot/state_machine.py
@@ -228,7 +228,7 @@ def state(f=None, *, first: bool = False, must_finish: bool = False):
     return _State(f, first, must_finish)
 
 
-def default_state(f: Callable):
+def default_state(f: StateMethod) -> _State:
     """
     If this decorator is applied to a method in an object that inherits
     from :class:`.StateMachine`, it indicates that the method

--- a/magicbot/state_machine.py
+++ b/magicbot/state_machine.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Sequence,
     Union,
+    overload,
 )
 
 import wpilib
@@ -193,7 +194,26 @@ def timed_state(
     return decorator
 
 
-def state(f=None, *, first: bool = False, must_finish: bool = False):
+@overload
+def state(
+    *,
+    first: bool = ...,
+    must_finish: bool = ...,
+) -> Callable[[StateMethod], _State]:
+    ...
+
+
+@overload
+def state(f: StateMethod) -> _State:
+    ...
+
+
+def state(
+    f: Optional[StateMethod] = None,
+    *,
+    first: bool = False,
+    must_finish: bool = False,
+) -> Union[Callable[[StateMethod], _State], _State]:
     """
     If this decorator is applied to a function in an object that inherits
     from :class:`.StateMachine`, it indicates that the function
@@ -217,7 +237,7 @@ def state(f=None, *, first: bool = False, must_finish: bool = False):
     """
 
     if f is None:
-        return functools.partial(state, first=first, must_finish=must_finish)
+        return lambda f: _State(f, first, must_finish)
 
     return _State(f, first, must_finish)
 

--- a/magicbot/state_machine.py
+++ b/magicbot/state_machine.py
@@ -1,11 +1,14 @@
 import functools
 import inspect
+import logging
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Dict,
     NoReturn,
     Optional,
+    Sequence,
     Union,
 )
 
@@ -374,10 +377,17 @@ class StateMachine:
 
     VERBOSE_LOGGING = False
 
+    #: A Python logging object automatically injected by magicbot.
+    #: It can be used to send messages to the log, instead of using print statements.
+    logger: logging.Logger
+
     #: NT variable that indicates which state will be executed next (though,
     #: does not guarantee that it will be executed). Will return an empty
     #: string if the state machine is not currently engaged.
     current_state = tunable("", subtable="state")
+
+    state_names: ClassVar[tunable[Sequence[str]]]
+    state_descriptions: ClassVar[tunable[Sequence[str]]]
 
     def __new__(cls):
         # choose to use __new__ instead of __init__

--- a/magicbot/state_machine.py
+++ b/magicbot/state_machine.py
@@ -389,7 +389,7 @@ class StateMachine:
     state_names: ClassVar[tunable[Sequence[str]]]
     state_descriptions: ClassVar[tunable[Sequence[str]]]
 
-    def __new__(cls):
+    def __new__(cls) -> "StateMachine":
         # choose to use __new__ instead of __init__
         o = super().__new__(cls)
         o._build_states()
@@ -398,7 +398,7 @@ class StateMachine:
         # TODO: when this gets invoked, tunables need to be setup on
         # the object first
 
-    def _build_states(self):
+    def _build_states(self) -> None:
         has_first = False
 
         # problem: the user interface won't know which entries are the


### PR DESCRIPTION
This adds more type hints to `magicbot.state_machine`.

There are changes to the `@timed_state` and `@state` decorators could be considered breaking changes, but would not affect any team code using decorator syntax (i.e. teams would have to be manually decorating their methods to observe a breaking change).