### PR TITLE
simple_watchdog: Call logger less

### DIFF
--- a/robotpy_ext/misc/simple_watchdog.py
+++ b/robotpy_ext/misc/simple_watchdog.py
@@ -83,13 +83,15 @@ class SimpleWatchdog:
             now > self._expirationTime
             and now - self._lastEpochsPrintTime > self.kMinPrintPeriod
         ):
-            log = logger.info
             self._lastEpochsPrintTime = now
             prev = self._startTime
-            log("Watchdog not fed after %.6fs", (now - prev) / 1e6)
+            logger.warning("Watchdog not fed after %.6fs", (now - prev) / 1e6)
+            epoch_logs = []
             for key, value in self._epochs:
-                log("\t%s: %.6fs", key, (value - prev) / 1e6)
+                time = (value - prev) / 1e6
+                epoch_logs.append(f"\t{key}: {time:.6f}")
                 prev = value
+            logger.info("Epochs:\n%s", "\n".join(epoch_logs))
 
     def reset(self) -> None:
         """Resets the watchdog timer.


### PR DESCRIPTION
A single logging call can be slower than one might expect on the roboRIO. The existing SimpleWatchdog logs aren't exactly super-readable in the console currently either.

This logs the epochs with a single info log call, instead of multiple info logs.

Also upgrade the `Watchdog not fed` log message to warning, to make it more noticeable.