### PR TITLE
magicbot: Fix isOperatorControlEnabled AttributeError

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -478,7 +478,7 @@ class MagicRobot(wpilib.RobotBase):
         observe = hal.observeUserProgramTeleop
 
         with NotifierDelay(self.control_loop_wait_time) as delay:
-            while not self.__done and self.isOperatorControlEnabled():
+            while not self.__done and self.isTeleopEnabled():
                 observe()
                 try:
                     self.teleopPeriodic()


### PR DESCRIPTION
:facepalm: turns out our unit tests don't cover this, but the examples do!

Verified locally with `mypy` and running the tests on the `magicbot-simple` example.