### PR TITLE
magicbot: Bound tunable/feedback value types

### DIFF
--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -4,9 +4,10 @@ import warnings
 from typing import Callable, Generic, Optional, TypeVar, overload
 
 from ntcore import NetworkTableInstance, Value
+from ntcore.types import ValueT
 
 T = TypeVar("T")
-V = TypeVar("V")
+V = TypeVar("V", bound=ValueT)
 
 
 class tunable(Generic[V]):

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,11 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development
     Topic :: Scientific/Engineering
 
@@ -29,11 +29,11 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    pyntcore>=2023.0.0b4
-    wpilib>=2023.0.0b4,<2024.0.0
+    pyntcore>=2023.2.1.4
+    wpilib>=2023.2.1,<2024
 setup_requires =
     setuptools_scm > 6
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.package_data]
 magicbot = py.typed, magic_reset.pyi


### PR DESCRIPTION
This makes the types that a `tunable` can be created with, or a `@feedback` method can return, stricter and match the types that are actually allowed at runtime. This will catch things like attempting to directly send a `Pose2d` early.

Uses https://github.com/robotpy/pyntcore/pull/43, so also bumps the dependencies.