### PR TITLE
magicbot: Inject into component __init__

### DIFF
--- a/magicbot/inject.py
+++ b/magicbot/inject.py
@@ -23,10 +23,13 @@ def get_injection_requests(
     for n, inject_type in type_hints.items():
         # If the variable is private ignore it
         if n.startswith("_"):
+            if component is None:
+                message = f"Cannot inject into component {cname} __init__ param {n}"
+                raise MagicInjectError(message)
             continue
 
         # If the variable has been set, skip it
-        if hasattr(component, n):
+        if component is not None and hasattr(component, n):
             continue
 
         # Check for generic types from the typing module

--- a/tests/test_magicbot_injection.py
+++ b/tests/test_magicbot_injection.py
@@ -1,4 +1,4 @@
-from typing import List, Type, TypeVar
+from typing import List, Tuple, Type, TypeVar
 from unittest.mock import Mock
 
 import magicbot
@@ -33,12 +33,30 @@ class Component2:
         pass
 
 
+class Component3:
+    intvar: int
+
+    def __init__(
+        self,
+        tupvar: Tuple[int, int],
+        injectable: Injectable,
+        component2: Component2,
+    ) -> None:
+        self.tuple_ = tupvar
+        self.injectable_ = injectable
+        self.component_2 = component2
+
+    def execute(self):
+        pass
+
+
 class SimpleBot(magicbot.MagicRobot):
     intvar = 1
     tupvar = 1, 2
 
     component1: Component1
     component2: Component2
+    component3: Component3
 
     def createObjects(self):
         self.injectable = Injectable(42)
@@ -157,6 +175,15 @@ def test_simple_annotation_inject():
 
     assert bot.component2.tupvar == (1, 2)
     assert bot.component2.component1 is bot.component1
+
+    assert bot.component3.intvar == 1
+    assert bot.component3.tuple_ == (1, 2)
+    assert isinstance(bot.component3.injectable_, Injectable)
+    assert bot.component3.injectable_.num == 42
+    assert bot.component3.component_2 is bot.component2
+
+    # Check the method hasn't been mutated
+    assert str(Component3.__init__.__annotations__["return"]) == "None"
 
 
 def test_multilevel_annotation_inject():


### PR DESCRIPTION
See #21

A good motivating example could look something like the following:

```python
class Vision:
	def __init__(self, name: str):
		self.camera = PhotonCamera(name)

	def execute(self): ...

class Robot(MagicRobot):
	vision: Vision

	def createObjects(self):
		self.vision_name = 'camera'
```

Of course, it could also be used like this, to make things less magic:

```python
@dataclass
class Chassis:
	module_a: SwerveModule
	module_b: SwerveModule
	module_c: SwerveModule

	def __post_init__(self): ...

	def execute(self): ...

class Robot(MagicRobot):
	chassis: Chassis

	def createObjects(self):
		self.chassis_module_a = SwerveModule(...)
		self.chassis_module_b = SwerveModule(...)
		self.chassis_module_c = SwerveModule(...)
```