### PR TITLE
magicbot: Fix non-type annotation error for init

### DIFF
--- a/magicbot/inject.py
+++ b/magicbot/inject.py
@@ -39,10 +39,12 @@ def get_injection_requests(
 
         # If the type is not actually a type, give a meaningful error
         if not isinstance(inject_type, type):
-            raise TypeError(
-                f"Component {cname} has a non-type annotation {n}: {inject_type}\n"
-                "Lone non-injection variable annotations are disallowed, did you want to assign a static variable?"
+            message = (
+                f"Component {cname} has a non-type annotation {n}: {inject_type!r}"
             )
+            if component is not None:
+                message += "\nLone non-injection variable annotations are disallowed. Did you mean to assign a static variable?"
+            raise TypeError(message)
 
         requests[n] = inject_type
 

--- a/tests/test_magicbot_inject.py
+++ b/tests/test_magicbot_inject.py
@@ -1,0 +1,20 @@
+import typing
+
+import pytest
+
+from magicbot.inject import get_injection_requests
+
+
+def test_ctor_invalid_type_hint_message():
+    """
+    class Component:
+        def __init__(self, foo: 1): ...
+    """
+    type_hints = {
+        "foo": typing.cast(type, 1),
+    }
+
+    with pytest.raises(TypeError) as exc_info:
+        get_injection_requests(type_hints, "bar")
+
+    assert exc_info.value.args[0] == "Component bar has a non-type annotation foo: 1"


### PR DESCRIPTION
Given the following component class:

    class Component:
        def __init__(self, foo: 1): ...

An error message that didn't make much sense contextually would be raised:

```pytb
Traceback (most recent call last):
  File ".../site-packages/wpilib/_impl/start.py", line 75, in start
    return self._start(robot_cls)
  File ".../site-packages/wpilib/_impl/start.py", line 163, in _start
    self.robot.startCompetition()
  File ".../site-packages/magicbot/magicrobot.py", line 361, in startCompetition
    self.robotInit()
  File ".../site-packages/magicbot/magicrobot.py", line 110, in robotInit
    self._create_components()
  File ".../site-packages/magicbot/magicrobot.py", line 616, in _create_components
    component = self._create_component(m, ctyp, injectables)
  File ".../site-packages/magicbot/magicrobot.py", line 683, in _create_component
    requests = get_injection_requests(type_hints, name)
  File ".../site-packages/magicbot/inject.py", line 42, in get_injection_requests
    raise TypeError(
TypeError: Component component1 has a non-type annotation foo: 1
Lone non-injection variable annotations are disallowed, did you want to assign a static variable?
```

This removes the bit about static variables when injecting into the `__init__` method.

Whilst we're here, also split that bit into two sentences to make it easier to read.