### PR TITLE
magicbot: Allow typed feedbacks using return type hints

### DIFF
--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -285,8 +285,10 @@ def _get_topic_type(
     origin = getattr(return_annotation, "__origin__", None)
     args = typing.get_args(return_annotation)
     if origin in (list, tuple, collections.abc.Sequence) and args:
-        # Ensure tuples are tuple[T, ...]
-        if origin is tuple and not (len(args) == 2 and args[1] is Ellipsis):
+        # Ensure tuples are tuple[T, ...] or homogenous
+        if origin is tuple and not (
+            (len(args) == 2 and args[1] is Ellipsis) or len(set(args)) == 1
+        ):
             return None
 
         inner_type = args[0]

--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -248,7 +248,7 @@ def _get_topic_type(
     # Check for PEP 484 generic types
     origin = getattr(return_annotation, "__origin__", None)
     args = typing.get_args(return_annotation)
-    if origin in (list, tuple) and args:
+    if origin in (list, tuple, collections.abc.Sequence) and args:
         # Ensure tuples are tuple[T, ...]
         if origin is tuple and not (len(args) == 2 and args[1] is Ellipsis):
             return None

--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -225,7 +225,7 @@ def feedback(f=None, *, key: Optional[str] = None) -> Callable:
 def collect_feedbacks(component, cname: str, prefix: Optional[str] = "components"):
     """
     Finds all methods decorated with :func:`feedback` on an object
-    and returns a list of 2-tuples (method, NetworkTables entry).
+    and returns a list of 2-tuples (method, NetworkTables entry setter).
 
     .. note:: This isn't useful for normal use.
     """
@@ -247,6 +247,7 @@ def collect_feedbacks(component, cname: str, prefix: Optional[str] = "components
                     key = name
 
             entry = nt.getEntry(key)
-            feedbacks.append((method, entry))
+            setter = entry.setValue
+            feedbacks.append((method, setter))
 
     return feedbacks

--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -60,6 +60,10 @@ class tunable(Generic[V]):
               you will want to use setup_tunables to set the object up.
               In normal usage, MagicRobot does this for you, so you don't
               have to do anything special.
+
+    .. versionchanged:: 2024.1.0
+       Added support for WPILib Struct serializable types.
+       Integer defaults now create integer topics instead of double topics.
     """
 
     # the way this works is we use a special class to indicate that it
@@ -229,6 +233,10 @@ def feedback(f=None, *, key: Optional[str] = None) -> Callable:
                  especially if you wish to monitor WPILib objects.
 
     .. versionadded:: 2018.1.0
+
+    .. versionchanged:: 2024.1.0
+       WPILib Struct serializable types are supported when the return type is type hinted.
+       An ``int`` return type hint now creates an integer topic.
     """
     if f is None:
         return functools.partial(feedback, key=key)

--- a/magicbot/magic_tunable.py
+++ b/magicbot/magic_tunable.py
@@ -1,3 +1,4 @@
+import collections.abc
 import functools
 import inspect
 import typing
@@ -244,6 +245,8 @@ def _get_topic_type(
 ) -> Optional[Callable[[ntcore.Topic], typing.Any]]:
     if return_annotation in _topic_types:
         return _topic_types[return_annotation]
+    if hasattr(return_annotation, "WPIStruct"):
+        return lambda topic: ntcore.StructTopic(topic, return_annotation)
 
     # Check for PEP 484 generic types
     origin = getattr(return_annotation, "__origin__", None)
@@ -256,6 +259,8 @@ def _get_topic_type(
         inner_type = args[0]
         if inner_type in _array_topic_types:
             return _array_topic_types[inner_type]
+        if hasattr(inner_type, "WPIStruct"):
+            return lambda topic: ntcore.StructArrayTopic(topic, inner_type)
 
 
 def collect_feedbacks(component, cname: str, prefix: Optional[str] = "components"):

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, List, Tuple
 import hal
 import wpilib
 
-from ntcore import NetworkTableInstance, NetworkTableEntry
+from ntcore import NetworkTableInstance
 
 # from wpilib.shuffleboard import Shuffleboard
 
@@ -73,7 +73,7 @@ class MagicRobot(wpilib.RobotBase):
         self.__last_error_report = -10
 
         self._components: List[Tuple[str, Any]] = []
-        self._feedbacks: List[Tuple[Callable[[], Any], NetworkTableEntry]] = []
+        self._feedbacks: List[Tuple[Callable[[], Any], Callable[[Any], Any]]] = []
         self._reset_components: List[Tuple[Dict[str, Any], Any]] = []
 
         self.__done = False
@@ -720,13 +720,13 @@ class MagicRobot(wpilib.RobotBase):
         """Run periodic methods which run in every mode."""
         watchdog = self.watchdog
 
-        for method, entry in self._feedbacks:
+        for method, setter in self._feedbacks:
             try:
                 value = method()
             except:
                 self.onException()
             else:
-                entry.setValue(value)
+                setter(value)
 
         watchdog.addEpoch("@magicbot.feedback")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    wpilib>=2024.1.1.0,<2025
+    wpilib>=2024.3.2.1,<2025
 setup_requires =
     setuptools_scm > 6
 python_requires = >=3.8

--- a/tests/test_magicbot_feedback.py
+++ b/tests/test_magicbot_feedback.py
@@ -44,6 +44,10 @@ class TypeHintedComponent:
     def get_ints(self) -> Sequence[int]:
         return (0,)
 
+    @magicbot.feedback
+    def get_empty_strings(self) -> Sequence[str]:
+        return ()
+
     def execute(self):
         pass
 
@@ -56,7 +60,7 @@ class Robot(magicbot.MagicRobot):
         pass
 
 
-def test_collect_feedbacks_with_type_hints():
+def test_feedbacks_with_type_hints():
     robot = Robot()
     robot.robotInit()
     nt = ntcore.NetworkTableInstance.getDefault().getTable("components")
@@ -70,6 +74,7 @@ def test_collect_feedbacks_with_type_hints():
         ("type_hinted/int", "int", 0),
         ("type_hinted/float", "double", 0.5),
         ("type_hinted/ints", "int[]", [0]),
+        ("type_hinted/empty_strings", "string[]", []),
     ):
         topic = nt.getTopic(name)
         assert topic.getTypeString() == type_str

--- a/tests/test_magicbot_feedback.py
+++ b/tests/test_magicbot_feedback.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import ntcore
 from wpimath import geometry
@@ -31,6 +31,10 @@ class TypeHintedComponent:
     @magicbot.feedback
     def get_rotation_array(self) -> Sequence[geometry.Rotation2d]:
         return [geometry.Rotation2d()]
+
+    @magicbot.feedback
+    def get_rotation_2_tuple(self) -> Tuple[geometry.Rotation2d, geometry.Rotation2d]:
+        return (geometry.Rotation2d(), geometry.Rotation2d())
 
     @magicbot.feedback
     def get_int(self) -> int:
@@ -90,6 +94,11 @@ def test_feedbacks_with_type_hints():
 
     for name, struct_type, value in (
         ("type_hinted/rotation_array", geometry.Rotation2d, [geometry.Rotation2d()]),
+        (
+            "type_hinted/rotation_2_tuple",
+            geometry.Rotation2d,
+            [geometry.Rotation2d(), geometry.Rotation2d()],
+        ),
     ):
         assert nt.getTopic(name).getTypeString() == f"struct:{struct_type.__name__}[]"
         topic = nt.getStructArrayTopic(name, struct_type)

--- a/tests/test_magicbot_feedback.py
+++ b/tests/test_magicbot_feedback.py
@@ -74,3 +74,18 @@ def test_collect_feedbacks_with_type_hints():
         topic = nt.getTopic(name)
         assert topic.getTypeString() == type_str
         assert topic.genericSubscribe().get().value() == value
+
+    for name, value in [
+        ("type_hinted/rotation", geometry.Rotation2d()),
+    ]:
+        struct_type = type(value)
+        assert nt.getTopic(name).getTypeString() == f"struct:{struct_type.__name__}"
+        topic = nt.getStructTopic(name, struct_type)
+        assert topic.subscribe(None).get() == value
+
+    for name, struct_type, value in (
+        ("type_hinted/rotation_array", geometry.Rotation2d, [geometry.Rotation2d()]),
+    ):
+        assert nt.getTopic(name).getTypeString() == f"struct:{struct_type.__name__}[]"
+        topic = nt.getStructArrayTopic(name, struct_type)
+        assert topic.subscribe([]).get() == value

--- a/tests/test_magicbot_feedback.py
+++ b/tests/test_magicbot_feedback.py
@@ -1,0 +1,76 @@
+from typing import Sequence
+
+import ntcore
+from wpimath import geometry
+
+import magicbot
+
+
+class BasicComponent:
+    @magicbot.feedback
+    def get_number(self):
+        return 0
+
+    @magicbot.feedback
+    def get_ints(self):
+        return (0,)
+
+    @magicbot.feedback
+    def get_floats(self):
+        return (0.0, 0)
+
+    def execute(self):
+        pass
+
+
+class TypeHintedComponent:
+    @magicbot.feedback
+    def get_rotation(self) -> geometry.Rotation2d:
+        return geometry.Rotation2d()
+
+    @magicbot.feedback
+    def get_rotation_array(self) -> Sequence[geometry.Rotation2d]:
+        return [geometry.Rotation2d()]
+
+    @magicbot.feedback
+    def get_int(self) -> int:
+        return 0
+
+    @magicbot.feedback
+    def get_float(self) -> float:
+        return 0.5
+
+    @magicbot.feedback
+    def get_ints(self) -> Sequence[int]:
+        return (0,)
+
+    def execute(self):
+        pass
+
+
+class Robot(magicbot.MagicRobot):
+    basic: BasicComponent
+    type_hinted: TypeHintedComponent
+
+    def createObjects(self):
+        pass
+
+
+def test_collect_feedbacks_with_type_hints():
+    robot = Robot()
+    robot.robotInit()
+    nt = ntcore.NetworkTableInstance.getDefault().getTable("components")
+
+    robot._do_periodics()
+
+    for name, type_str, value in (
+        ("basic/number", "double", 0.0),
+        ("basic/ints", "int[]", [0]),
+        ("basic/floats", "double[]", [0.0, 0.0]),
+        ("type_hinted/int", "int", 0),
+        ("type_hinted/float", "double", 0.5),
+        ("type_hinted/ints", "int[]", [0]),
+    ):
+        topic = nt.getTopic(name)
+        assert topic.getTypeString() == type_str
+        assert topic.genericSubscribe().get().value() == value

--- a/tests/test_magicbot_tunable.py
+++ b/tests/test_magicbot_tunable.py
@@ -1,0 +1,56 @@
+import ntcore
+import pytest
+from wpimath import geometry
+
+from magicbot.magic_tunable import setup_tunables, tunable
+
+
+def test_tunable() -> None:
+    class Component:
+        an_int = tunable(1)
+        ints = tunable([0])
+        floats = tunable([1.0, 2.0])
+        rotation = tunable(geometry.Rotation2d())
+        rotations = tunable([geometry.Rotation2d()])
+
+    component = Component()
+    setup_tunables(component, "test_tunable")
+    nt = ntcore.NetworkTableInstance.getDefault().getTable("/components/test_tunable")
+
+    for name, type_str, value in [
+        ("an_int", "int", 1),
+        ("ints", "int[]", [0]),
+        ("floats", "double[]", [1.0, 2.0]),
+    ]:
+        topic = nt.getTopic(name)
+        assert topic.getTypeString() == type_str
+        assert topic.genericSubscribe().get().value() == value
+
+    for name, value in [
+        ("rotation", geometry.Rotation2d()),
+    ]:
+        struct_type = type(value)
+        assert nt.getTopic(name).getTypeString() == f"struct:{struct_type.__name__}"
+        topic = nt.getStructTopic(name, struct_type)
+        assert topic.subscribe(None).get() == value
+
+    for name, struct_type, value in [
+        ("rotations", geometry.Rotation2d, [geometry.Rotation2d()]),
+    ]:
+        assert nt.getTopic(name).getTypeString() == f"struct:{struct_type.__name__}[]"
+        topic = nt.getStructArrayTopic(name, struct_type)
+        assert topic.subscribe([]).get() == value
+
+
+def test_tunable_errors():
+    with pytest.raises(TypeError):
+
+        class Component:
+            invalid = tunable(None)
+
+
+def test_tunable_errors_with_empty_sequence():
+    with pytest.raises(ValueError):
+
+        class Component:
+            empty = tunable([])


### PR DESCRIPTION
This inspects the return type hint on `@feedback` methods to determine what topic type they should publish. This allows:

- publishing integers to NetworkTables instead of floating point numbers (previously not possible due to the backwards compatibility in pyntcore's `setValue` method preferring to upcast integers to doubles),
- publishing empty arrays to NetworkTables,
- publishing structs and struct arrays to NetworkTables (not supported by `setValue`), and
- deterministically publishing integer or double arrays to NetworkTables (currently `setValue` always uses the type of the first element).

If the types are incompatible at runtime, the robot code will crash, e.g. in tests:

```pytb
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../.venv/lib/python3.11/site-packages/pytest_reraise/reraise.py:72: in __call__
    raise e
../../../pyfrc/pyfrc/test_support/controller.py:40: in _robot_thread
    robot.startCompetition()
../../../robotpy-wpilib-utilities/magicbot/magicrobot.py:370: in startCompetition
    self._disabled()
../../../robotpy-wpilib-utilities/magicbot/magicrobot.py:456: in _disabled
    self._do_periodics()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <robot.MyRobot object at 0x10687a0f0>

    def _do_periodics(self) -> None:
        """Run periodic methods which run in every mode."""
        watchdog = self.watchdog

        for method, setter in self._feedbacks:
            try:
                value = method()
            except:
                self.onException()
            else:
>               setter(value)
E               TypeError: set(): incompatible function arguments. The following argument types are supported:
E                   1. (self: ntcore._ntcore.IntegerPublisher, value: int, time: int = 0) -> None
E
E               Invoked with: <ntcore._ntcore.IntegerPublisher object at 0x1019ce5f0>, 0.0

../../../robotpy-wpilib-utilities/magicbot/magicrobot.py:729: TypeError
```

To appease type checkers without majorly refactoring the `magic_tunable` module further, this also adds support for int and struct tunables. This fixes the inferred type being wrong for `tunable(1)` (it claimed it was an int tunable, when reading it gave floats instead). Tunables with empty array defaults using type hints will be supported in a later PR.

I recommend reviewing this PR commit by commit.