### PR TITLE
move variable resettting to periodics

### DIFF
--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -729,6 +729,9 @@ class MagicRobot(wpilib.RobotBase):
                 self.onException()
             else:
                 setter(value)
+        
+        for reset_dict, component in self._reset_components:
+            component.__dict__.update(reset_dict)
 
         watchdog.addEpoch("@magicbot.feedback")
 
@@ -748,6 +751,3 @@ class MagicRobot(wpilib.RobotBase):
             watchdog.addEpoch(name)
 
         self._do_periodics()
-
-        for reset_dict, component in self._reset_components:
-            component.__dict__.update(reset_dict)

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -729,15 +729,15 @@ class MagicRobot(wpilib.RobotBase):
                 self.onException()
             else:
                 setter(value)
-        
-        for reset_dict, component in self._reset_components:
-            component.__dict__.update(reset_dict)
 
         watchdog.addEpoch("@magicbot.feedback")
 
         for periodic, name in self.__periodics:
             periodic()
             watchdog.addEpoch(name)
+
+        for reset_dict, component in self._reset_components:
+            component.__dict__.update(reset_dict)
 
     def _enabled_periodic(self) -> None:
         """Run components and all periodic methods."""


### PR DESCRIPTION
I think this technically fits the docs better for something that resets after every control cycle better than it only happening in teleop and auto. Maybe there is a case in which people don't want this to run in disabled but I cant think of what it might be off the top of my head. I can probably make a test for this calling `do_periodics` like in `test_magicbot_feedback.py` is there any value in making it more complicated to check that it does the bits in all modes? rather than just doing it on periodic?