### PR TITLE
MagicBot commands integration

### DIFF
--- a/docs/magicbot.rst
+++ b/docs/magicbot.rst
@@ -51,3 +51,39 @@ State machines
     :exclude-members: members
     :undoc-members:
     :show-inheritance:
+
+Commands
+~~~~~~~~
+
+.. automodule:: magicbot.commands
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+``magicbot.commands.CommandRunner`` is a MagicBot component that executes
+stored ``commands2.Command`` instances using keep-alive semantics.
+
+Call ``self.cmd.run(command)`` each loop that a stored command instance should
+remain active. If a command is not re-requested on a later loop, it is ended as
+interrupted when it is interruptible.
+
+Important usage constraints:
+
+- construct command instances once and store them on the robot/component
+- do not create a new command inside ``execute()`` or a state method each loop
+- components, state machines, and robot code may all call ``run(command)``
+- multiple different commands may run concurrently
+- this is not ``commands2.CommandScheduler`` and does not perform full
+  scheduler-style requirement arbitration
+
+Example::
+
+    class Shooter:
+        cmd: magicbot.commands.CommandRunner
+
+        def setup(self):
+            self.fire = FireCommand(...)
+
+        def execute(self):
+            if should_fire():
+                self.cmd.run(self.fire)

--- a/magicbot/__init__.py
+++ b/magicbot/__init__.py
@@ -1,5 +1,3 @@
-from . import commands
-from .commands import CommandRunner
 from .magicrobot import MagicRobot
 from .magic_tunable import feedback, tunable
 from .magic_reset import will_reset_to
@@ -13,8 +11,6 @@ from .state_machine import (
 )
 
 __all__ = (
-    "commands",
-    "CommandRunner",
     "MagicRobot",
     "feedback",
     "tunable",

--- a/magicbot/__init__.py
+++ b/magicbot/__init__.py
@@ -1,3 +1,5 @@
+from . import commands
+from .commands import CommandRunner
 from .magicrobot import MagicRobot
 from .magic_tunable import feedback, tunable
 from .magic_reset import will_reset_to
@@ -11,6 +13,8 @@ from .state_machine import (
 )
 
 __all__ = (
+    "commands",
+    "CommandRunner",
     "MagicRobot",
     "feedback",
     "tunable",

--- a/magicbot/commands.py
+++ b/magicbot/commands.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import commands2
+
+
+class CommandRunner:
+    def run(self, command: commands2.Command) -> None:
+        raise NotImplementedError
+
+    def execute(self) -> None:
+        raise NotImplementedError

--- a/magicbot/commands.py
+++ b/magicbot/commands.py
@@ -4,8 +4,40 @@ import commands2
 
 
 class CommandRunner:
+    def __init__(self) -> None:
+        self._requested: set[commands2.Command] = set()
+        self._active: set[commands2.Command] = set()
+
     def run(self, command: commands2.Command) -> None:
-        raise NotImplementedError
+        self._requested.add(command)
 
     def execute(self) -> None:
-        raise NotImplementedError
+        stale = [
+            command
+            for command in self._active
+            if command not in self._requested
+            and command.getInterruptionBehavior()
+            != commands2.Command.InterruptionBehavior.kCancelIncoming
+        ]
+        for command in stale:
+            command.end(True)
+            self._active.remove(command)
+
+        new_commands = [
+            command for command in self._requested if command not in self._active
+        ]
+        for command in new_commands:
+            command.initialize()
+            self._active.add(command)
+
+        finished: list[commands2.Command] = []
+        for command in list(self._active):
+            command.execute()
+            if command.isFinished():
+                command.end(False)
+                finished.append(command)
+
+        for command in finished:
+            self._active.remove(command)
+
+        self._requested.clear()

--- a/magicbot/commands.py
+++ b/magicbot/commands.py
@@ -25,7 +25,7 @@ class CommandRunner:
     robot: object
 
     def __init__(self) -> None:
-        self._requested: set[commands2.Command] = set()
+        self._requested: dict[commands2.Command, None] = {}
         self._active: set[commands2.Command] = set()
 
     def run(self, command: commands2.Command) -> None:
@@ -33,10 +33,10 @@ class CommandRunner:
         Request that a stored command instance remain active for the current
         robot loop.
         """
-        self._requested.add(command)
+        self._requested.setdefault(command, None)
 
     def _discard(self, command: commands2.Command) -> None:
-        self._requested.discard(command)
+        self._requested.pop(command, None)
         self._active.discard(command)
 
     def _call(self, command: commands2.Command, func: Callable[[], object]) -> bool:
@@ -68,7 +68,9 @@ class CommandRunner:
                 self._active.add(command)
 
         finished: list[commands2.Command] = []
-        for command in list(self._active):
+        for command in list(self._requested):
+            if command not in self._active:
+                continue
             if not self._call(command, command.execute):
                 continue
             if command.isFinished():

--- a/magicbot/commands.py
+++ b/magicbot/commands.py
@@ -1,15 +1,32 @@
 from __future__ import annotations
 
+from typing import Callable
+
 import commands2
 
 
 class CommandRunner:
+    robot: object
+
     def __init__(self) -> None:
         self._requested: set[commands2.Command] = set()
         self._active: set[commands2.Command] = set()
 
     def run(self, command: commands2.Command) -> None:
         self._requested.add(command)
+
+    def _discard(self, command: commands2.Command) -> None:
+        self._requested.discard(command)
+        self._active.discard(command)
+
+    def _call(self, command: commands2.Command, func: Callable[[], object]) -> bool:
+        try:
+            func()
+        except Exception:
+            self._discard(command)
+            self.robot.onException()
+            return False
+        return True
 
     def execute(self) -> None:
         stale = [
@@ -20,22 +37,23 @@ class CommandRunner:
             != commands2.Command.InterruptionBehavior.kCancelIncoming
         ]
         for command in stale:
-            command.end(True)
-            self._active.remove(command)
+            if self._call(command, lambda command=command: command.end(True)):
+                self._active.remove(command)
 
         new_commands = [
             command for command in self._requested if command not in self._active
         ]
         for command in new_commands:
-            command.initialize()
-            self._active.add(command)
+            if self._call(command, command.initialize):
+                self._active.add(command)
 
         finished: list[commands2.Command] = []
         for command in list(self._active):
-            command.execute()
+            if not self._call(command, command.execute):
+                continue
             if command.isFinished():
-                command.end(False)
-                finished.append(command)
+                if self._call(command, lambda command=command: command.end(False)):
+                    finished.append(command)
 
         for command in finished:
             self._active.remove(command)

--- a/magicbot/commands.py
+++ b/magicbot/commands.py
@@ -6,6 +6,22 @@ import commands2
 
 
 class CommandRunner:
+    """
+    A MagicBot component that executes ``commands2.Command`` instances using
+    keep-alive semantics.
+
+    Call :meth:`run` each loop that a stored command instance should remain
+    active. Commands that are not re-requested on a later loop are interrupted
+    automatically if they are interruptible.
+
+    Multiple different commands may be active concurrently. Repeated
+    :meth:`run` calls for the same command instance in a single loop are
+    deduplicated.
+
+    This component intentionally does not expose or depend on
+    ``commands2.CommandScheduler``.
+    """
+
     robot: object
 
     def __init__(self) -> None:
@@ -13,6 +29,10 @@ class CommandRunner:
         self._active: set[commands2.Command] = set()
 
     def run(self, command: commands2.Command) -> None:
+        """
+        Request that a stored command instance remain active for the current
+        robot loop.
+        """
         self._requested.add(command)
 
     def _discard(self, command: commands2.Command) -> None:

--- a/magicbot/commands.py
+++ b/magicbot/commands.py
@@ -10,9 +10,8 @@ class CommandRunner:
     A MagicBot component that executes ``commands2.Command`` instances using
     keep-alive semantics.
 
-    Call :meth:`run` each loop that a stored command instance should remain
-    active. Commands that are not re-requested on a later loop are interrupted
-    automatically if they are interruptible.
+    Call :meth:`run` to start a stored command instance. Once started, a
+    command continues running on each later loop until it reports finished.
 
     Multiple different commands may be active concurrently. Repeated
     :meth:`run` calls for the same command instance in a single loop are
@@ -26,18 +25,17 @@ class CommandRunner:
 
     def __init__(self) -> None:
         self._requested: dict[commands2.Command, None] = {}
-        self._active: set[commands2.Command] = set()
+        self._active: dict[commands2.Command, None] = {}
 
     def run(self, command: commands2.Command) -> None:
         """
-        Request that a stored command instance remain active for the current
-        robot loop.
+        Request that a stored command instance start running.
         """
         self._requested.setdefault(command, None)
 
     def _discard(self, command: commands2.Command) -> None:
         self._requested.pop(command, None)
-        self._active.discard(command)
+        self._active.pop(command, None)
 
     def _call(self, command: commands2.Command, func: Callable[[], object]) -> bool:
         try:
@@ -49,28 +47,22 @@ class CommandRunner:
         return True
 
     def execute(self) -> None:
-        stale = [
-            command
-            for command in self._active
-            if command not in self._requested
-            and command.getInterruptionBehavior()
-            != commands2.Command.InterruptionBehavior.kCancelIncoming
-        ]
-        for command in stale:
-            if self._call(command, lambda command=command: command.end(True)):
-                self._active.remove(command)
-
         new_commands = [
             command for command in self._requested if command not in self._active
         ]
         for command in new_commands:
             if self._call(command, command.initialize):
-                self._active.add(command)
+                self._active[command] = None
+
+        commands_to_execute = [
+            command for command in self._requested if command in self._active
+        ]
+        commands_to_execute.extend(
+            command for command in self._active if command not in self._requested
+        )
 
         finished: list[commands2.Command] = []
-        for command in list(self._requested):
-            if command not in self._active:
-                continue
+        for command in commands_to_execute:
             if not self._call(command, command.execute):
                 continue
             if command.isFinished():
@@ -78,6 +70,6 @@ class CommandRunner:
                     finished.append(command)
 
         for command in finished:
-            self._active.remove(command)
+            self._active.pop(command, None)
 
         self._requested.clear()

--- a/magicbot/magicrobot.py
+++ b/magicbot/magicrobot.py
@@ -692,7 +692,7 @@ class MagicRobot(wpilib.RobotBase):
         self._components = components
 
     def _collect_injectables(self) -> dict[str, Any]:
-        injectables = {}
+        injectables = {"robot": self}
         cls = type(self)
 
         for n in dir(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
   "toposort",
   "wpilib>=2026.1.1,<2027",
+  "robotpy-commands-v2>=2026.1.1,<2027",
 ]
 
 [[project.authors]]

--- a/tests/test_magicbot_commands.py
+++ b/tests/test_magicbot_commands.py
@@ -166,17 +166,17 @@ def test_command_runner_keeps_alive_requested_command():
     assert command.end_calls == []
 
 
-def test_command_runner_interrupts_command_not_requested_next_loop():
+def test_command_runner_keeps_running_until_finished_without_run_call():
     _, runner = make_runner()
-    command = RecordingCommand()
+    command = RecordingCommand(finished_after=2)
 
     runner.run(command)
     runner.execute()
     runner.execute()
 
     assert command.initialize_calls == 1
-    assert command.execute_calls == 1
-    assert command.end_calls == [True]
+    assert command.execute_calls == 2
+    assert command.end_calls == [False]
 
 
 def test_command_runner_deduplicates_same_command_requested_twice():

--- a/tests/test_magicbot_commands.py
+++ b/tests/test_magicbot_commands.py
@@ -28,6 +28,27 @@ class RecordingCommand(commands2.Command):
         self.end_calls.append(interrupted)
 
 
+class OrderedRecordingCommand(RecordingCommand):
+    def __init__(
+        self, name: str, events: list[tuple[str, str]], *, hash_value: int
+    ) -> None:
+        super().__init__()
+        self.name = name
+        self.events = events
+        self.hash_value = hash_value
+
+    def __hash__(self) -> int:
+        return self.hash_value
+
+    def initialize(self):
+        super().initialize()
+        self.events.append(("initialize", self.name))
+
+    def execute(self):
+        super().execute()
+        self.events.append(("execute", self.name))
+
+
 class RaiseOnInitialize(commands2.Command):
     def initialize(self):
         raise RuntimeError("initialize boom")
@@ -183,6 +204,32 @@ def test_command_runner_executes_multiple_commands_concurrently():
     assert first.execute_calls == 1
     assert second.initialize_calls == 1
     assert second.execute_calls == 1
+
+
+def test_command_runner_executes_commands_in_run_call_order():
+    _, runner = make_runner()
+    events: list[tuple[str, str]] = []
+    first = OrderedRecordingCommand("first", events, hash_value=1)
+    second = OrderedRecordingCommand("second", events, hash_value=8)
+
+    runner.run(first)
+    runner.run(second)
+    runner.execute()
+
+    assert events == [
+        ("initialize", "first"),
+        ("initialize", "second"),
+        ("execute", "first"),
+        ("execute", "second"),
+    ]
+
+    events.clear()
+
+    runner.run(second)
+    runner.run(first)
+    runner.execute()
+
+    assert events == [("execute", "second"), ("execute", "first")]
 
 
 def test_command_runner_delegates_initialize_exception_to_robot():

--- a/tests/test_magicbot_commands.py
+++ b/tests/test_magicbot_commands.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import commands2
 import magicbot
+import magicbot.commands
 
 
 class RecordingCommand(commands2.Command):

--- a/tests/test_magicbot_commands.py
+++ b/tests/test_magicbot_commands.py
@@ -1,0 +1,245 @@
+from unittest.mock import Mock
+
+import commands2
+import magicbot
+
+
+class RecordingCommand(commands2.Command):
+    def __init__(self, *, finished_after: int | None = None) -> None:
+        super().__init__()
+        self.finished_after = finished_after
+        self.initialize_calls = 0
+        self.execute_calls = 0
+        self.end_calls: list[bool] = []
+
+    def initialize(self):
+        self.initialize_calls += 1
+
+    def execute(self):
+        self.execute_calls += 1
+
+    def isFinished(self) -> bool:
+        return (
+            self.finished_after is not None
+            and self.execute_calls >= self.finished_after
+        )
+
+    def end(self, interrupted: bool):
+        self.end_calls.append(interrupted)
+
+
+class RaiseOnInitialize(commands2.Command):
+    def initialize(self):
+        raise RuntimeError("initialize boom")
+
+
+class RaiseOnExecute(commands2.Command):
+    def execute(self):
+        raise RuntimeError("execute boom")
+
+
+class RaiseOnEnd(commands2.Command):
+    def __init__(self):
+        super().__init__()
+        self.executed = False
+
+    def execute(self):
+        self.executed = True
+
+    def isFinished(self) -> bool:
+        return self.executed
+
+    def end(self, interrupted: bool):
+        raise RuntimeError("end boom")
+
+
+class RecordingRobot(magicbot.MagicRobot):
+    def createObjects(self):
+        pass
+
+    def onException(self, forceReport: bool = False) -> None:
+        self.on_exception_calls += 1
+
+
+class UsesCommand:
+    cmd: "magicbot.commands.CommandRunner"
+
+    def setup(self):
+        self.command = RecordingCommand()
+        self.should_run = False
+
+    def execute(self):
+        if self.should_run:
+            self.cmd.run(self.command)
+
+
+class AlsoUsesCommand:
+    cmd: "magicbot.commands.CommandRunner"
+
+    def setup(self):
+        self.command = RecordingCommand()
+        self.should_run = False
+
+    def execute(self):
+        if self.should_run:
+            self.cmd.run(self.command)
+
+
+class ComponentRobot(RecordingRobot):
+    cmd: "magicbot.commands.CommandRunner"
+    first: UsesCommand
+    second: AlsoUsesCommand
+
+    def createObjects(self):
+        self.on_exception_calls = 0
+        self._automodes = Mock()
+        self._automodes.modes = {}
+
+
+def make_runner():
+    robot = RecordingRobot()
+    robot.on_exception_calls = 0
+    runner = magicbot.commands.CommandRunner()
+    runner.robot = robot
+    return robot, runner
+
+
+def make_component_robot() -> ComponentRobot:
+    robot = ComponentRobot()
+    robot.createObjects()
+    robot._create_components()
+    return robot
+
+
+def test_command_runner_initializes_executes_and_finishes_once():
+    _, runner = make_runner()
+    command = RecordingCommand(finished_after=2)
+
+    runner.run(command)
+    runner.execute()
+
+    assert command.initialize_calls == 1
+    assert command.execute_calls == 1
+    assert command.end_calls == []
+
+    runner.run(command)
+    runner.execute()
+
+    assert command.initialize_calls == 1
+    assert command.execute_calls == 2
+    assert command.end_calls == [False]
+
+
+def test_command_runner_keeps_alive_requested_command():
+    _, runner = make_runner()
+    command = RecordingCommand()
+
+    runner.run(command)
+    runner.execute()
+    runner.run(command)
+    runner.execute()
+
+    assert command.initialize_calls == 1
+    assert command.execute_calls == 2
+    assert command.end_calls == []
+
+
+def test_command_runner_interrupts_command_not_requested_next_loop():
+    _, runner = make_runner()
+    command = RecordingCommand()
+
+    runner.run(command)
+    runner.execute()
+    runner.execute()
+
+    assert command.initialize_calls == 1
+    assert command.execute_calls == 1
+    assert command.end_calls == [True]
+
+
+def test_command_runner_deduplicates_same_command_requested_twice():
+    _, runner = make_runner()
+    command = RecordingCommand()
+
+    runner.run(command)
+    runner.run(command)
+    runner.execute()
+
+    assert command.initialize_calls == 1
+    assert command.execute_calls == 1
+    assert command.end_calls == []
+
+
+def test_command_runner_executes_multiple_commands_concurrently():
+    _, runner = make_runner()
+    first = RecordingCommand()
+    second = RecordingCommand()
+
+    runner.run(first)
+    runner.run(second)
+    runner.execute()
+
+    assert first.initialize_calls == 1
+    assert first.execute_calls == 1
+    assert second.initialize_calls == 1
+    assert second.execute_calls == 1
+
+
+def test_command_runner_delegates_initialize_exception_to_robot():
+    robot, runner = make_runner()
+    command = RaiseOnInitialize()
+
+    runner.run(command)
+    runner.execute()
+
+    assert robot.on_exception_calls == 1
+
+
+def test_command_runner_delegates_execute_exception_to_robot():
+    robot, runner = make_runner()
+    command = RaiseOnExecute()
+
+    runner.run(command)
+    runner.execute()
+
+    assert robot.on_exception_calls == 1
+
+
+def test_command_runner_delegates_end_exception_to_robot():
+    robot, runner = make_runner()
+    command = RaiseOnEnd()
+
+    runner.run(command)
+    runner.execute()
+
+    assert robot.on_exception_calls == 1
+
+
+def test_command_runner_works_as_magicbot_component():
+    robot = make_component_robot()
+
+    robot.first.should_run = True
+    robot.first.execute()
+    robot.cmd.execute()
+
+    assert robot.first.command.initialize_calls == 1
+    assert robot.first.command.execute_calls == 1
+
+
+def test_command_runner_supports_basic_command_group():
+    _, runner = make_runner()
+    first = RecordingCommand(finished_after=1)
+    second = RecordingCommand(finished_after=1)
+    group = commands2.cmd.sequence(first, second)
+
+    runner.run(group)
+    runner.execute()
+    runner.run(group)
+    runner.execute()
+
+    assert first.initialize_calls == 1
+    assert first.execute_calls == 1
+    assert first.end_calls == [False]
+    assert second.initialize_calls == 1
+    assert second.execute_calls == 1
+    assert second.end_calls == [False]


### PR DESCRIPTION
Disclaimer: all of this is AI slop, haven't tested it at all... but it all kinda makes sense?

* Fixes #215

# MagicBot Commands Design

## Summary

This design adds a MagicBot-native way to execute `commands2` command objects without adopting `commands2.CommandScheduler`.

The goal is to let teams reuse existing command-based examples and command objects within a MagicBot robot while preserving MagicBot's execution model.

The recommended approach is a keep-alive command runner implemented as a MagicBot component in `magicbot.commands`.

## Goals

- Allow MagicBot teams to execute stored `commands2.Command` instances
- Support ordinary commands plus command groups/decorators where lifecycle execution is sufficient
- Preserve MagicBot semantics instead of embedding the command scheduler
- Keep the public API extremely small and ergonomic
- Allow commands to be requested from robot code, components, or state machines

## Non-goals

- Do not use or expose `commands2.CommandScheduler`
- Do not recreate full command-based subsystem/requirement arbitration
- Do not implement trigger binding, default commands, or scheduler event hooks in v1
- Do not encourage constructing new command instances every loop

## Recommended Architecture

Three approaches were considered:

1. **Scheduler-backed adapter**: hide a real `CommandScheduler` behind a MagicBot façade. This would maximize compatibility, but it violates the goal of not using the scheduler and would import scheduler semantics into MagicBot.
2. **Slot-based runner**: `run("drive", cmd)` or one runner per domain. This is predictable, but adds coordination burden and feels unlike normal MagicBot usage.
3. **Keep-alive command runner**: expose only `run(command)`, where a command remains active only while some code requests it each loop.

The recommended design is **the keep-alive command runner**.

## Component Model

The feature should be implemented as a MagicBot component, for example `magicbot.commands.CommandRunner`.

Teams would declare and inject it like any other component/service:

```python
class MyRobot(magicbot.MagicRobot):
    cmd: magicbot.commands.CommandRunner
```

MagicBot's normal component lifecycle would invoke the runner's `execute()` method every loop. This keeps the implementation aligned with existing framework behavior and avoids special robot-level scheduling hooks.

## Public API

The public API should intentionally stay minimal:

```python
self.cmd.run(command)
```

Semantics:

- `run(command)` means: this command should remain active for the current loop
- users should construct command instances once and store them on the robot/component
- users should not create a brand new command object every loop
- duplicate `run()` calls for the same command instance in the same loop are harmless and deduplicated
- multiple different commands may be active concurrently
- components, state machines, and robot code may all call `run()` whenever appropriate

## Lifecycle Semantics

Internally, the runner tracks command instances by object identity.

At a high level it maintains:

- a set of commands requested this loop
- a set of currently active commands

On each `execute()` call, the runner should:

1. record all `run(command)` requests made since the previous `execute()`
2. initialize any newly requested commands that are not already active
3. execute each active command once
4. end and remove commands whose `isFinished()` reports true
5. cancel commands that were previously active but were not requested this loop, if they are interruptible
6. clear the per-loop requested set and prepare for the next cycle

This gives command execution declarative, MagicBot-style keep-alive behavior.

## Concurrency Model

The runner should allow concurrent execution of multiple command instances.

Rules:

- if two different components call `self.cmd.run(...)` with different commands in the same loop, both should run concurrently
- if multiple components call `self.cmd.run(...)` with the same stored command instance, it is treated as a single request and runs only once
- the runner does not track ownership of commands by a specific component

This loose ownership matches MagicBot's cooperative model.

## Compatibility Boundary

The runner should accept ordinary `commands2.Command` instances, including command groups and decorator-produced wrappers, so long as they behave correctly when driven through the standard command lifecycle.

The v1 compatibility target is intentionally narrower than the full command framework runtime:

- support command lifecycle execution
- support command groups/decorators to the extent they work through lifecycle calls alone
- do not implement full subsystem registration or requirement arbitration
- do not implement trigger binding or default command semantics
- do not attempt to fully mirror scheduler internals

This keeps the feature useful without rebuilding the scheduler.

## Conflict Handling

The runner should not perform its own requirement arbitration in v1.

That means:

- independently requested commands may run concurrently
- if two commands would have conflicted under `CommandScheduler`, the runner will not automatically resolve that conflict
- command groups/decorators that manage their own child behavior internally should continue to work as normal

The documentation should clearly state that `magicbot.commands` is a MagicBot-native lifecycle runner, not a full replacement for scheduler-based orchestration.

## Exception Handling

Exception behavior should follow MagicBot's existing model.

If a command raises from `initialize()`, `execute()`, or `end(interrupted)`, the runner should:

1. catch the exception at the command boundary
2. remove the failing command from the active set
3. delegate exception handling to `MagicRobot.onException(...)`

This preserves current MagicBot behavior:

- when FMS is not attached, exceptions still crash loudly during development
- when FMS is attached, exceptions are reported through MagicBot's existing throttled driver-station reporting path

The runner should not invent new exception swallowing or logging behavior inconsistent with `MagicRobot`.

## Robot Integration

Because exceptions must route through `MagicRobot.onException(...)`, the runner needs access to the owning robot instance.

This should be wired using MagicBot's existing injection/component mechanisms instead of special global state.

## Example Usage

A stripped-down intended usage pattern looks like:

```python
class Drive:
    cmd: "magicbot.commands.CommandRunner"

    def setup(self):
        self.drive_forward = SomeDriveCommand(...)

    def execute(self):
        if want_drive_forward():
            self.cmd.run(self.drive_forward)
```

```python
class Intake:
    cmd: "magicbot.commands.CommandRunner"

    def setup(self):
        self.intake_note = SomeIntakeCommand(...)

    def execute(self):
        if want_intake():
            self.cmd.run(self.intake_note)
```

Important guidance for users:

- construct commands once
- store them on the robot/component
- pass the stored instance to `run()` each loop it should stay active
- do not create commands inline in `execute()`

## Testing Plan

Unit tests should verify:

- newly requested commands are initialized exactly once
- active commands are executed once per runner `execute()`
- commands that report finished are ended normally and removed
- commands not re-requested are ended as interrupted when appropriate
- duplicate `run()` calls for the same instance in one loop do not duplicate execution
- multiple distinct commands can run concurrently
- an exception in `initialize()`, `execute()`, or `end()` removes the command and delegates to `onException`
- at least one command group/decorator-style object works with the runner's lifecycle model

## Future Extensions

Possible later improvements, if teams need them:

- optional debug warnings for suspicious per-loop command construction patterns
- additional introspection/status APIs
- opt-in conflict detection or lightweight requirement handling
- richer examples showing migration from command-based examples to MagicBot usage

These should be deferred until real usage demonstrates need.
